### PR TITLE
Use onComplete callback instead of EventLoopFuture

### DIFF
--- a/Sources/HummingbirdCore/HTTPResponder.swift
+++ b/Sources/HummingbirdCore/HTTPResponder.swift
@@ -38,7 +38,7 @@ public protocol HBHTTPResponder {
     /// - Parameters:
     ///   - request: HTTP request
     ///   - context: ChannelHandlerContext from channel that request was served on.
-    func respond(to request: HBHTTPRequest, context: ChannelHandlerContext) -> EventLoopFuture<HBHTTPResponse>
+    func respond(to request: HBHTTPRequest, context: ChannelHandlerContext, onComplete: @escaping (Result<HBHTTPResponse, Error>) -> ())
 
     /// Logger used by responder
     var logger: Logger? { get }

--- a/Sources/HummingbirdCore/HTTPResponder.swift
+++ b/Sources/HummingbirdCore/HTTPResponder.swift
@@ -38,7 +38,7 @@ public protocol HBHTTPResponder {
     /// - Parameters:
     ///   - request: HTTP request
     ///   - context: ChannelHandlerContext from channel that request was served on.
-    func respond(to request: HBHTTPRequest, context: ChannelHandlerContext, onComplete: @escaping (Result<HBHTTPResponse, Error>) -> ())
+    func respond(to request: HBHTTPRequest, context: ChannelHandlerContext, onComplete: @escaping (Result<HBHTTPResponse, Error>) -> Void)
 
     /// Logger used by responder
     var logger: Logger? { get }

--- a/Sources/HummingbirdCore/Request/RequestBodyStreamer.swift
+++ b/Sources/HummingbirdCore/Request/RequestBodyStreamer.swift
@@ -121,12 +121,12 @@ public class HBRequestBodyStreamer {
     func drop() -> EventLoopFuture<Void> {
         self.eventLoop.assertInEventLoop()
         self.dropped = true
-        
+
         let promise = self.eventLoop.makePromise(of: Void.self)
         func _dropAll() {
-            self.consume(on: eventLoop).map { output in
+            self.consume(on: self.eventLoop).map { output in
                 switch output {
-                case .byteBuffer(_):
+                case .byteBuffer:
                     _dropAll()
 
                 case .end:

--- a/Sources/HummingbirdCore/Server/HTTPServerHandler.swift
+++ b/Sources/HummingbirdCore/Server/HTTPServerHandler.swift
@@ -45,7 +45,7 @@ final class HBHTTPServerHandler: ChannelInboundHandler, RemovableChannelHandler 
 
         // respond to request
         self.responder.respond(to: request, context: context) { result in
-            // should we keep the channel open after responding. 
+            // should we keep the channel open after responding.
             let keepAlive = request.head.isKeepAlive && (self.closeAfterResponseWritten == false || self.requestsInProgress > 1)
             var response: HBHTTPResponse
             switch result {

--- a/Sources/HummingbirdCore/Server/HTTPServerHandler.swift
+++ b/Sources/HummingbirdCore/Server/HTTPServerHandler.swift
@@ -44,7 +44,7 @@ final class HBHTTPServerHandler: ChannelInboundHandler, RemovableChannelHandler 
         self.requestsInProgress += 1
 
         // respond to request
-        self.responder.respond(to: request, context: context).whenComplete { result in
+        self.responder.respond(to: request, context: context) { result in
             // should we keep the channel open after responding. 
             let keepAlive = request.head.isKeepAlive && (self.closeAfterResponseWritten == false || self.requestsInProgress > 1)
             var response: HBHTTPResponse

--- a/Tests/HummingbirdCoreTests/CoreTests.swift
+++ b/Tests/HummingbirdCoreTests/CoreTests.swift
@@ -27,7 +27,7 @@ class HummingBirdCoreTests: XCTestCase {
 
     func testConnect() {
         struct HelloResponder: HBHTTPResponder {
-            func respond(to request: HBHTTPRequest, context: ChannelHandlerContext, onComplete: @escaping (Result<HBHTTPResponse, Error>) -> ()) {
+            func respond(to request: HBHTTPRequest, context: ChannelHandlerContext, onComplete: @escaping (Result<HBHTTPResponse, Error>) -> Void) {
                 let responseHead = HTTPResponseHead(version: .init(major: 1, minor: 1), status: .ok)
                 let responseBody = context.channel.allocator.buffer(string: "Hello")
                 let response = HBHTTPResponse(head: responseHead, body: .byteBuffer(responseBody))
@@ -50,7 +50,7 @@ class HummingBirdCoreTests: XCTestCase {
 
     func testConsumeBody() {
         struct Responder: HBHTTPResponder {
-            func respond(to request: HBHTTPRequest, context: ChannelHandlerContext, onComplete: @escaping (Result<HBHTTPResponse, Error>) -> ()) {
+            func respond(to request: HBHTTPRequest, context: ChannelHandlerContext, onComplete: @escaping (Result<HBHTTPResponse, Error>) -> Void) {
                 request.body.consumeBody(on: context.eventLoop).whenComplete { result in
                     switch result {
                     case .success(let buffer):
@@ -88,7 +88,7 @@ class HummingBirdCoreTests: XCTestCase {
 
     func testConsumeAllBody() {
         struct Responder: HBHTTPResponder {
-            func respond(to request: HBHTTPRequest, context: ChannelHandlerContext, onComplete: @escaping (Result<HBHTTPResponse, Error>) -> ()) {
+            func respond(to request: HBHTTPRequest, context: ChannelHandlerContext, onComplete: @escaping (Result<HBHTTPResponse, Error>) -> Void) {
                 var size = 0
                 request.body.stream!.consumeAll(on: context.eventLoop) { buffer in
                     size += buffer.readableBytes
@@ -127,7 +127,7 @@ class HummingBirdCoreTests: XCTestCase {
 
     func testStreamBody() {
         struct Responder: HBHTTPResponder {
-            func respond(to request: HBHTTPRequest, context: ChannelHandlerContext, onComplete: @escaping (Result<HBHTTPResponse, Error>) -> ()) {
+            func respond(to request: HBHTTPRequest, context: ChannelHandlerContext, onComplete: @escaping (Result<HBHTTPResponse, Error>) -> Void) {
                 let body: HBResponseBody = .streamCallback { _ in
                     return request.body.stream!.consume(on: context.eventLoop).map { output in
                         switch output {
@@ -164,7 +164,7 @@ class HummingBirdCoreTests: XCTestCase {
 
     func testStreamBodySlowProcess() {
         struct Responder: HBHTTPResponder {
-            func respond(to request: HBHTTPRequest, context: ChannelHandlerContext, onComplete: @escaping (Result<HBHTTPResponse, Error>) -> ()) {
+            func respond(to request: HBHTTPRequest, context: ChannelHandlerContext, onComplete: @escaping (Result<HBHTTPResponse, Error>) -> Void) {
                 let body: HBResponseBody = .streamCallback { _ in
                     return request.body.stream!.consume(on: context.eventLoop).flatMap { output in
                         switch output {
@@ -213,7 +213,7 @@ class HummingBirdCoreTests: XCTestCase {
             }
         }
         struct Responder: HBHTTPResponder {
-            func respond(to request: HBHTTPRequest, context: ChannelHandlerContext, onComplete: @escaping (Result<HBHTTPResponse, Error>) -> ()) {
+            func respond(to request: HBHTTPRequest, context: ChannelHandlerContext, onComplete: @escaping (Result<HBHTTPResponse, Error>) -> Void) {
                 request.body.consumeBody(on: context.eventLoop).whenComplete { result in
                     let result = result.flatMap { buffer -> Result<HBHTTPResponse, Error> in
                         guard let buffer = buffer else {
@@ -260,7 +260,7 @@ class HummingBirdCoreTests: XCTestCase {
             }
         }
         struct Responder: HBHTTPResponder {
-            func respond(to request: HBHTTPRequest, context: ChannelHandlerContext, onComplete: @escaping (Result<HBHTTPResponse, Error>) -> ()) {
+            func respond(to request: HBHTTPRequest, context: ChannelHandlerContext, onComplete: @escaping (Result<HBHTTPResponse, Error>) -> Void) {
                 let response = HBHTTPResponse(
                     head: .init(version: .init(major: 1, minor: 1), status: .accepted),
                     body: .empty
@@ -287,7 +287,7 @@ class HummingBirdCoreTests: XCTestCase {
 
     func testMaxUploadSize() {
         struct Responder: HBHTTPResponder {
-            func respond(to request: HBHTTPRequest, context: ChannelHandlerContext, onComplete: @escaping (Result<HBHTTPResponse, Error>) -> ()) {
+            func respond(to request: HBHTTPRequest, context: ChannelHandlerContext, onComplete: @escaping (Result<HBHTTPResponse, Error>) -> Void) {
                 request.body.consumeBody(on: context.eventLoop).whenComplete { result in
                     let result = result.flatMap { buffer -> Result<HBHTTPResponse, Error> in
                         guard let buffer = buffer else {

--- a/Tests/HummingbirdCoreTests/CoreTests.swift
+++ b/Tests/HummingbirdCoreTests/CoreTests.swift
@@ -27,12 +27,11 @@ class HummingBirdCoreTests: XCTestCase {
 
     func testConnect() {
         struct HelloResponder: HBHTTPResponder {
-            func respond(to request: HBHTTPRequest, context: ChannelHandlerContext) -> EventLoopFuture<HBHTTPResponse> {
-                let response = HBHTTPResponse(
-                    head: .init(version: .init(major: 1, minor: 1), status: .ok),
-                    body: .byteBuffer(context.channel.allocator.buffer(string: "Hello"))
-                )
-                return context.eventLoop.makeSucceededFuture(response)
+            func respond(to request: HBHTTPRequest, context: ChannelHandlerContext, onComplete: @escaping (Result<HBHTTPResponse, Error>) -> ()) {
+                let responseHead = HTTPResponseHead(version: .init(major: 1, minor: 1), status: .ok)
+                let responseBody = context.channel.allocator.buffer(string: "Hello")
+                let response = HBHTTPResponse(head: responseHead, body: .byteBuffer(responseBody))
+                onComplete(.success(response))
             }
         }
         let server = HBHTTPServer(group: Self.eventLoopGroup, configuration: .init(address: .hostname(port: 8080)))
@@ -51,15 +50,22 @@ class HummingBirdCoreTests: XCTestCase {
 
     func testConsumeBody() {
         struct Responder: HBHTTPResponder {
-            func respond(to request: HBHTTPRequest, context: ChannelHandlerContext) -> EventLoopFuture<HBHTTPResponse> {
-                return request.body.consumeBody(on: context.eventLoop).flatMapThrowing { buffer in
-                    guard let buffer = buffer else {
-                        throw HBHTTPError(.badRequest)
+            func respond(to request: HBHTTPRequest, context: ChannelHandlerContext, onComplete: @escaping (Result<HBHTTPResponse, Error>) -> ()) {
+                request.body.consumeBody(on: context.eventLoop).whenComplete { result in
+                    switch result {
+                    case .success(let buffer):
+                        guard let buffer = buffer else {
+                            onComplete(.failure(HBHTTPError(.badRequest)))
+                            return
+                        }
+                        let response = HBHTTPResponse(
+                            head: .init(version: .init(major: 1, minor: 1), status: .ok),
+                            body: .byteBuffer(buffer)
+                        )
+                        onComplete(.success(response))
+                    case .failure(let error):
+                        onComplete(.failure(error))
                     }
-                    return HBHTTPResponse(
-                        head: .init(version: .init(major: 1, minor: 1), status: .ok),
-                        body: .byteBuffer(buffer)
-                    )
                 }
             }
         }
@@ -82,17 +88,23 @@ class HummingBirdCoreTests: XCTestCase {
 
     func testConsumeAllBody() {
         struct Responder: HBHTTPResponder {
-            func respond(to request: HBHTTPRequest, context: ChannelHandlerContext) -> EventLoopFuture<HBHTTPResponse> {
+            func respond(to request: HBHTTPRequest, context: ChannelHandlerContext, onComplete: @escaping (Result<HBHTTPResponse, Error>) -> ()) {
                 var size = 0
-                return request.body.stream!.consumeAll(on: context.eventLoop) { buffer in
+                request.body.stream!.consumeAll(on: context.eventLoop) { buffer in
                     size += buffer.readableBytes
                     return context.eventLoop.makeSucceededFuture(())
                 }
-                .flatMapThrowing { _ in
-                    return HBHTTPResponse(
-                        head: .init(version: .init(major: 1, minor: 1), status: .ok),
-                        body: .byteBuffer(context.channel.allocator.buffer(integer: size))
-                    )
+                .whenComplete { result in
+                    switch result {
+                    case .success:
+                        let response = HBHTTPResponse(
+                            head: .init(version: .init(major: 1, minor: 1), status: .ok),
+                            body: .byteBuffer(context.channel.allocator.buffer(integer: size))
+                        )
+                        onComplete(.success(response))
+                    case .failure(let error):
+                        onComplete(.failure(error))
+                    }
                 }
             }
         }
@@ -115,7 +127,7 @@ class HummingBirdCoreTests: XCTestCase {
 
     func testStreamBody() {
         struct Responder: HBHTTPResponder {
-            func respond(to request: HBHTTPRequest, context: ChannelHandlerContext) -> EventLoopFuture<HBHTTPResponse> {
+            func respond(to request: HBHTTPRequest, context: ChannelHandlerContext, onComplete: @escaping (Result<HBHTTPResponse, Error>) -> ()) {
                 let body: HBResponseBody = .streamCallback { _ in
                     return request.body.stream!.consume(on: context.eventLoop).map { output in
                         switch output {
@@ -130,7 +142,7 @@ class HummingBirdCoreTests: XCTestCase {
                     head: .init(version: .init(major: 1, minor: 1), status: .ok),
                     body: body
                 )
-                return context.eventLoop.makeSucceededFuture(response)
+                return onComplete(.success(response))
             }
         }
         let server = HBHTTPServer(group: Self.eventLoopGroup, configuration: .init(address: .hostname(port: 8080), maxStreamingBufferSize: 256 * 1024))
@@ -152,7 +164,7 @@ class HummingBirdCoreTests: XCTestCase {
 
     func testStreamBodySlowProcess() {
         struct Responder: HBHTTPResponder {
-            func respond(to request: HBHTTPRequest, context: ChannelHandlerContext) -> EventLoopFuture<HBHTTPResponse> {
+            func respond(to request: HBHTTPRequest, context: ChannelHandlerContext, onComplete: @escaping (Result<HBHTTPResponse, Error>) -> ()) {
                 let body: HBResponseBody = .streamCallback { _ in
                     return request.body.stream!.consume(on: context.eventLoop).flatMap { output in
                         switch output {
@@ -168,7 +180,7 @@ class HummingBirdCoreTests: XCTestCase {
                     head: .init(version: .init(major: 1, minor: 1), status: .ok),
                     body: body
                 )
-                return context.eventLoop.makeSucceededFuture(response)
+                onComplete(.success(response))
             }
         }
         let server = HBHTTPServer(group: Self.eventLoopGroup, configuration: .init(address: .hostname(port: 8080), maxStreamingBufferSize: 256 * 1024))
@@ -201,15 +213,19 @@ class HummingBirdCoreTests: XCTestCase {
             }
         }
         struct Responder: HBHTTPResponder {
-            func respond(to request: HBHTTPRequest, context: ChannelHandlerContext) -> EventLoopFuture<HBHTTPResponse> {
-                return request.body.consumeBody(on: context.eventLoop).flatMapThrowing { buffer in
-                    guard let buffer = buffer else {
-                        throw HBHTTPError(.badRequest)
+            func respond(to request: HBHTTPRequest, context: ChannelHandlerContext, onComplete: @escaping (Result<HBHTTPResponse, Error>) -> ()) {
+                request.body.consumeBody(on: context.eventLoop).whenComplete { result in
+                    let result = result.flatMap { buffer -> Result<HBHTTPResponse, Error> in
+                        guard let buffer = buffer else {
+                            return .failure(HBHTTPError(.badRequest))
+                        }
+                        let response = HBHTTPResponse(
+                            head: .init(version: .init(major: 1, minor: 1), status: .ok),
+                            body: .byteBuffer(buffer)
+                        )
+                        return .success(response)
                     }
-                    return HBHTTPResponse(
-                        head: .init(version: .init(major: 1, minor: 1), status: .ok),
-                        body: .byteBuffer(buffer)
-                    )
+                    onComplete(result)
                 }
             }
         }
@@ -244,12 +260,12 @@ class HummingBirdCoreTests: XCTestCase {
             }
         }
         struct Responder: HBHTTPResponder {
-            func respond(to request: HBHTTPRequest, context: ChannelHandlerContext) -> EventLoopFuture<HBHTTPResponse> {
+            func respond(to request: HBHTTPRequest, context: ChannelHandlerContext, onComplete: @escaping (Result<HBHTTPResponse, Error>) -> ()) {
                 let response = HBHTTPResponse(
                     head: .init(version: .init(major: 1, minor: 1), status: .accepted),
                     body: .empty
                 )
-                return context.eventLoop.makeSucceededFuture(response)
+                onComplete(.success(response))
             }
         }
         let server = HBHTTPServer(group: Self.eventLoopGroup, configuration: .init(address: .hostname(port: 8080)))
@@ -271,15 +287,19 @@ class HummingBirdCoreTests: XCTestCase {
 
     func testMaxUploadSize() {
         struct Responder: HBHTTPResponder {
-            func respond(to request: HBHTTPRequest, context: ChannelHandlerContext) -> EventLoopFuture<HBHTTPResponse> {
-                return request.body.consumeBody(on: context.eventLoop).flatMapThrowing { buffer in
-                    guard let buffer = buffer else {
-                        throw HBHTTPError(.badRequest)
+            func respond(to request: HBHTTPRequest, context: ChannelHandlerContext, onComplete: @escaping (Result<HBHTTPResponse, Error>) -> ()) {
+                request.body.consumeBody(on: context.eventLoop).whenComplete { result in
+                    let result = result.flatMap { buffer -> Result<HBHTTPResponse, Error> in
+                        guard let buffer = buffer else {
+                            return .failure(HBHTTPError(.badRequest))
+                        }
+                        let response = HBHTTPResponse(
+                            head: .init(version: .init(major: 1, minor: 1), status: .ok),
+                            body: .byteBuffer(buffer)
+                        )
+                        return .success(response)
                     }
-                    return HBHTTPResponse(
-                        head: .init(version: .init(major: 1, minor: 1), status: .ok),
-                        body: .byteBuffer(buffer)
-                    )
+                    onComplete(result)
                 }
             }
         }

--- a/Tests/HummingbirdTLSTests/HummingBirdTLSTests.swift
+++ b/Tests/HummingbirdTLSTests/HummingBirdTLSTests.swift
@@ -9,11 +9,11 @@ import XCTest
 
 class HummingBirdTLSTests: XCTestCase {
     struct HelloResponder: HBHTTPResponder {
-        func respond(to request: HBHTTPRequest, context: ChannelHandlerContext) -> EventLoopFuture<HBHTTPResponse> {
+        func respond(to request: HBHTTPRequest, context: ChannelHandlerContext, onComplete: @escaping (Result<HBHTTPResponse, Error>) -> ()) {
             let responseHead = HTTPResponseHead(version: .init(major: 1, minor: 1), status: .ok)
             let responseBody = context.channel.allocator.buffer(string: "Hello")
             let response = HBHTTPResponse(head: responseHead, body: .byteBuffer(responseBody))
-            return context.eventLoop.makeSucceededFuture(response)
+            onComplete(.success(response))
         }
 
         var logger: Logger? = Logger(label: "Core")

--- a/Tests/HummingbirdTLSTests/HummingBirdTLSTests.swift
+++ b/Tests/HummingbirdTLSTests/HummingBirdTLSTests.swift
@@ -9,7 +9,7 @@ import XCTest
 
 class HummingBirdTLSTests: XCTestCase {
     struct HelloResponder: HBHTTPResponder {
-        func respond(to request: HBHTTPRequest, context: ChannelHandlerContext, onComplete: @escaping (Result<HBHTTPResponse, Error>) -> ()) {
+        func respond(to request: HBHTTPRequest, context: ChannelHandlerContext, onComplete: @escaping (Result<HBHTTPResponse, Error>) -> Void) {
             let responseHead = HTTPResponseHead(version: .init(major: 1, minor: 1), status: .ok)
             let responseBody = context.channel.allocator.buffer(string: "Hello")
             let response = HBHTTPResponse(head: responseHead, body: .byteBuffer(responseBody))


### PR DESCRIPTION
Means we aren't forcing people into an asynchronous environment