### PR TITLE
Add AsyncSequence support to HBStreamerProtocol

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        image: ['swift:5.4-bionic', 'swift:5.4-focal', 'swift:5.4-amazonlinux2', 'swift:5.4-centos8']
-    
+        image:
+          - 'swift:5.4-bionic'
+          - 'swift:5.4-focal'
+          - 'swift:5.4-amazonlinux2'
+          - 'swift:5.4-centos8'
+          - 'swiftlang/swift:nightly-5.5-focal'
     container:
       image: ${{ matrix.image }}
     steps:

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-log.git", from: "1.4.0"),
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.26.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.32.1"),
         .package(url: "https://github.com/apple/swift-nio-extras.git", from: "1.7.0"),
         .package(url: "https://github.com/apple/swift-nio-http2.git", from: "1.16.1"),
         .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.14.0"),
@@ -27,6 +27,7 @@ let package = Package(
             .product(name: "NIOExtras", package: "swift-nio-extras"),
             .product(name: "NIOHTTP1", package: "swift-nio"),
             .product(name: "NIOPosix", package: "swift-nio"),
+            .product(name: "_NIOConcurrency", package: "swift-nio"),
             .product(name: "NIOTransportServices", package: "swift-nio-transport-services"),
         ]),
         .target(name: "HummingbirdCoreXCT", dependencies: [

--- a/Sources/HummingbirdCore/AsyncAwaitSupport/RequestBodyStreamer+async.swift
+++ b/Sources/HummingbirdCore/AsyncAwaitSupport/RequestBodyStreamer+async.swift
@@ -1,0 +1,74 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Hummingbird server framework project
+//
+// Copyright (c) 2021-2021 the Hummingbird authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See hummingbird/CONTRIBUTORS.txt for the list of Hummingbird authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#if compiler(>=5.5)
+
+import NIOCore
+import _NIOConcurrency
+
+@available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+extension HBStreamerProtocol {
+    public var sequence: HBRequestBodyStreamerSequence { return .init(streamer: self) }
+}
+
+@available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+extension HBRequestBodyStreamer {
+    public func consume() async throws -> HBRequestBodyStreamer.ConsumeOutput {
+        return try await self.eventLoop.flatSubmit {
+            self.consume()
+        }.get()
+
+    }
+}
+
+@available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+extension HBByteBufferStreamer {
+    public func consume() -> HBRequestBodyStreamer.ConsumeOutput {
+        guard let output = self.byteBuffer.readSlice(length: self.byteBuffer.readableBytes) else {
+            return .end
+        }
+        if output.readableBytes == 0 {
+            return .end
+        }
+        return .byteBuffer(output)
+    }
+}
+
+@available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+public struct HBRequestBodyStreamerSequence: AsyncSequence {
+    public typealias Element = ByteBuffer
+
+    let streamer: HBStreamerProtocol
+
+    public struct AsyncIterator: AsyncIteratorProtocol {
+        let streamer: HBStreamerProtocol
+        
+        public func next() async throws -> ByteBuffer? {
+            let output = try await self.streamer.consume()
+            switch output {
+            case .byteBuffer(let buffer):
+                return buffer
+            case .end:
+                return nil
+            }
+        }
+    }
+
+    /// Make async iterator
+    public func makeAsyncIterator() -> AsyncIterator {
+        return AsyncIterator(streamer: self.streamer)
+    }
+}
+
+#endif // compiler(>=5.5)

--- a/Sources/HummingbirdCore/AsyncAwaitSupport/RequestBodyStreamer+async.swift
+++ b/Sources/HummingbirdCore/AsyncAwaitSupport/RequestBodyStreamer+async.swift
@@ -14,8 +14,8 @@
 
 #if compiler(>=5.5)
 
-import NIOCore
 import _NIOConcurrency
+import NIOCore
 
 @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
 extension HBStreamerProtocol {
@@ -28,7 +28,6 @@ extension HBRequestBodyStreamer {
         return try await self.eventLoop.flatSubmit {
             self.consume()
         }.get()
-
     }
 }
 
@@ -53,7 +52,7 @@ public struct HBRequestBodyStreamerSequence: AsyncSequence {
 
     public struct AsyncIterator: AsyncIteratorProtocol {
         let streamer: HBStreamerProtocol
-        
+
         public func next() async throws -> ByteBuffer? {
             let output = try await self.streamer.consume()
             switch output {

--- a/Sources/HummingbirdCore/Request/RequestBodyStreamer.swift
+++ b/Sources/HummingbirdCore/Request/RequestBodyStreamer.swift
@@ -17,12 +17,12 @@ import NIOCore
 public protocol HBStreamerProtocol {
     func consume(on eventLoop: EventLoop) -> EventLoopFuture<HBRequestBodyStreamer.ConsumeOutput>
     func consumeAll(on eventLoop: EventLoop, _ process: @escaping (ByteBuffer) -> EventLoopFuture<Void>) -> EventLoopFuture<Void>
-    
+
     #if compiler(>=5.5)
 
     @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
     func consume() async throws -> HBRequestBodyStreamer.ConsumeOutput
-    
+
     #endif // compiler(>=5.5)
 }
 

--- a/Sources/HummingbirdCore/Request/RequestBodyStreamer.swift
+++ b/Sources/HummingbirdCore/Request/RequestBodyStreamer.swift
@@ -17,6 +17,13 @@ import NIOCore
 public protocol HBStreamerProtocol {
     func consume(on eventLoop: EventLoop) -> EventLoopFuture<HBRequestBodyStreamer.ConsumeOutput>
     func consumeAll(on eventLoop: EventLoop, _ process: @escaping (ByteBuffer) -> EventLoopFuture<Void>) -> EventLoopFuture<Void>
+    
+    #if compiler(>=5.5)
+
+    @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+    func consume() async throws -> HBRequestBodyStreamer.ConsumeOutput
+    
+    #endif // compiler(>=5.5)
 }
 
 /// Request body streamer. `HBHTTPDecodeHandler` feeds this with ByteBuffers while the Router consumes them

--- a/Tests/HummingbirdCoreTests/CoreTests+async.swift
+++ b/Tests/HummingbirdCoreTests/CoreTests+async.swift
@@ -1,0 +1,82 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Hummingbird server framework project
+//
+// Copyright (c) 2021-2021 the Hummingbird authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See hummingbird/CONTRIBUTORS.txt for the list of Hummingbird authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#if compiler(>=5.5)
+
+import HummingbirdCore
+import HummingbirdCoreXCT
+import NIOCore
+import NIOPosix
+import XCTest
+
+@available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+final class HummingBirdCoreAsyncTests: XCTestCase {
+    static var eventLoopGroup: EventLoopGroup!
+
+    override class func setUp() {
+        #if os(iOS)
+        self.eventLoopGroup = NIOTSEventLoopGroup()
+        #else
+        self.eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
+        #endif
+    }
+
+    override class func tearDown() {
+        XCTAssertNoThrow(try self.eventLoopGroup.syncShutdownGracefully())
+    }
+
+    func randomBuffer(size: Int) -> ByteBuffer {
+        var data = [UInt8](repeating: 0, count: size)
+        data = data.map { _ in UInt8.random(in: 0...255) }
+        return ByteBufferAllocator().buffer(bytes: data)
+    }
+
+    func testStreamBody() {
+        struct Responder: HBHTTPResponder {
+            func respond(to request: HBHTTPRequest, context: ChannelHandlerContext, onComplete: @escaping (Result<HBHTTPResponse, Error>) -> Void) {
+                let allocator = context.channel.allocator
+                Task { 
+                    var responseBuffer = allocator.buffer(capacity: 0)
+                    for try await buffer in request.body.stream!.sequence {
+                        var buffer = buffer
+                        responseBuffer.writeBuffer(&buffer)
+                    }
+                    let response = HBHTTPResponse(
+                        head: .init(version: .init(major: 1, minor: 1), status: .ok),
+                        body: .byteBuffer(responseBuffer)
+                    )
+                    onComplete(.success(response))
+                }
+            }
+        }
+        let server = HBHTTPServer(group: Self.eventLoopGroup, configuration: .init(address: .hostname(port: 0), maxStreamingBufferSize: 256 * 1024))
+        XCTAssertNoThrow(try server.start(responder: Responder()).wait())
+        defer { XCTAssertNoThrow(try server.stop().wait()) }
+
+        let client = HBXCTClient(host: "localhost", port: server.port!, eventLoopGroupProvider: .createNew)
+        client.connect()
+        defer { XCTAssertNoThrow(try client.syncShutdown()) }
+
+        let buffer = self.randomBuffer(size: 1_140_000)
+        let future = client.post("/", body: buffer)
+            .flatMapThrowing { response in
+                let body = try XCTUnwrap(response.body)
+                XCTAssertEqual(body, buffer)
+            }
+        XCTAssertNoThrow(try future.wait())
+    }
+
+}
+
+#endif // compiler(>=5.5)

--- a/Tests/HummingbirdCoreTests/CoreTests+async.swift
+++ b/Tests/HummingbirdCoreTests/CoreTests+async.swift
@@ -46,7 +46,7 @@ final class HummingBirdCoreAsyncTests: XCTestCase {
         struct Responder: HBHTTPResponder {
             func respond(to request: HBHTTPRequest, context: ChannelHandlerContext, onComplete: @escaping (Result<HBHTTPResponse, Error>) -> Void) {
                 let allocator = context.channel.allocator
-                Task { 
+                Task {
                     var responseBuffer = allocator.buffer(capacity: 0)
                     for try await buffer in request.body.stream!.sequence {
                         var buffer = buffer
@@ -76,7 +76,6 @@ final class HummingBirdCoreAsyncTests: XCTestCase {
             }
         XCTAssertNoThrow(try future.wait())
     }
-
 }
 
 #endif // compiler(>=5.5)


### PR DESCRIPTION
Add var `sequence` to HBStreamerProtocol which can be used as an `AsyncSequence`. Unfortunately I can't extend a protocol conditionally with a protocol conformance otherwise I would have just extended `HBStreamerProtocol` to conform to `AsyncSequence`

```swift
guard let stream = request.body.stream else { ... }
for try await buffer in stream.sequence {
    ...
}
```