### PR TITLE
Remove unnecessary writeHTTPParts allocation

### DIFF
--- a/Sources/HummingbirdCore/Server/HTTPServerHandler.swift
+++ b/Sources/HummingbirdCore/Server/HTTPServerHandler.swift
@@ -157,7 +157,7 @@ final class HBHTTPServerHandler: ChannelDuplexHandler, RemovableChannelHandler {
     }
 
     func writeResponse(context: ChannelHandlerContext, response: HBHTTPResponse, streamer: HBRequestBodyStreamer?, keepAlive: Bool) {
-        self.writeHTTPParts(context: context, response: response).whenComplete { result in
+        self.writeHTTPParts(context: context, response: response).whenComplete { _ in
             // once we have finished writing the response we can drop the request body
             // if we are streaming we need to wait until the request has finished streaming
             if let streamer = streamer {

--- a/Sources/HummingbirdCore/Server/HTTPServerHandler.swift
+++ b/Sources/HummingbirdCore/Server/HTTPServerHandler.swift
@@ -158,10 +158,6 @@ final class HBHTTPServerHandler: ChannelDuplexHandler, RemovableChannelHandler {
 
     func writeResponse(context: ChannelHandlerContext, response: HBHTTPResponse, streamer: HBRequestBodyStreamer?, keepAlive: Bool) {
         self.writeHTTPParts(context: context, response: response).whenComplete { result in
-            var keepAlive = keepAlive
-            if case .failure = result {
-                keepAlive = false
-            }
             // once we have finished writing the response we can drop the request body
             // if we are streaming we need to wait until the request has finished streaming
             if let streamer = streamer {


### PR DESCRIPTION
Don't use result from writeAndFlush so don't create promise for it. Return static successful void future