### PR TITLE
ByteBuffer Response Streamer version 2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
     - name: SPM tests
-      run: swift test --enable-code-coverage --sanitize=thread
+      run: swift test --enable-code-coverage
     - name: Convert coverage files
       run: |
         xcrun llvm-cov export -format "lcov" \

--- a/Sources/HummingbirdCore/AsyncAwaitSupport/RequestBodyStreamer+async.swift
+++ b/Sources/HummingbirdCore/AsyncAwaitSupport/RequestBodyStreamer+async.swift
@@ -23,9 +23,9 @@ extension HBStreamerProtocol {
 }
 
 @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
-extension HBRequestBodyStreamer {
+extension HBByteBufferStreamer {
     /// Consume what has been fed to the request so far
-    public func consume() async throws -> HBRequestBodyStreamer.ConsumeOutput {
+    public func consume() async throws -> HBStreamerOutput {
         return try await self.eventLoop.flatSubmit {
             self.consume()
         }.get()
@@ -33,9 +33,9 @@ extension HBRequestBodyStreamer {
 }
 
 @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
-extension HBByteBufferStreamer {
+extension HBStaticStreamer {
     /// Consume what has been fed to the request so far
-    public func consume() -> HBRequestBodyStreamer.ConsumeOutput {
+    public func consume() -> HBStreamerOutput {
         guard let output = self.byteBuffer.readSlice(length: self.byteBuffer.readableBytes) else {
             return .end
         }

--- a/Sources/HummingbirdCore/Request/ByteBufferStreamer.swift
+++ b/Sources/HummingbirdCore/Request/ByteBufferStreamer.swift
@@ -75,7 +75,7 @@ public final class HBByteBufferStreamer: HBStreamerProtocol {
     /// - Parameter result: Bytebuffer or end tag
     public func feed(_ result: FeedInput) {
         if self.eventLoop.inEventLoop {
-            _feed(result)
+            self._feed(result)
         } else {
             self.eventLoop.execute {
                 self._feed(result)

--- a/Sources/HummingbirdCore/Request/ByteBufferStreamer.swift
+++ b/Sources/HummingbirdCore/Request/ByteBufferStreamer.swift
@@ -14,20 +14,26 @@
 
 import NIOCore
 
+/// Values returned when we consume the contents of the streamer
+public enum HBStreamerOutput {
+    case byteBuffer(ByteBuffer)
+    case end
+}
+
 public protocol HBStreamerProtocol {
-    func consume(on eventLoop: EventLoop) -> EventLoopFuture<HBRequestBodyStreamer.ConsumeOutput>
+    func consume(on eventLoop: EventLoop) -> EventLoopFuture<HBStreamerOutput>
     func consumeAll(on eventLoop: EventLoop, _ process: @escaping (ByteBuffer) -> EventLoopFuture<Void>) -> EventLoopFuture<Void>
 
     #if compiler(>=5.5) && canImport(_Concurrency)
 
     @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
-    func consume() async throws -> HBRequestBodyStreamer.ConsumeOutput
+    func consume() async throws -> HBStreamerOutput
 
     #endif // compiler(>=5.5) && canImport(_Concurrency)
 }
 
 /// Request body streamer. `HBHTTPDecodeHandler` feeds this with ByteBuffers while the Router consumes them
-public final class HBRequestBodyStreamer: HBStreamerProtocol {
+public final class HBByteBufferStreamer: HBStreamerProtocol {
     public enum StreamerError: Swift.Error {
         case bodyDropped
     }
@@ -39,18 +45,12 @@ public final class HBRequestBodyStreamer: HBStreamerProtocol {
         case end
     }
 
-    /// Values returned when we consume the contents of the streamer
-    public enum ConsumeOutput {
-        case byteBuffer(ByteBuffer)
-        case end
-    }
-
     /// Queue of promises for each ByteBuffer fed to the streamer. Last entry is always waiting for the next buffer or end tag
-    var queue: CircularBuffer<EventLoopPromise<ConsumeOutput>>
+    var queue: CircularBuffer<EventLoopPromise<HBStreamerOutput>>
     /// EventLoop everything is running on
     let eventLoop: EventLoop
     /// called every time a ByteBuffer is consumed
-    var onConsume: ((HBRequestBodyStreamer) -> Void)?
+    var onConsume: ((HBByteBufferStreamer) -> Void)?
     /// maximum allowed size to upload
     let maxSize: Int
     /// current size in memory
@@ -60,7 +60,7 @@ public final class HBRequestBodyStreamer: HBStreamerProtocol {
     /// has request streamer data been dropped
     var dropped: Bool
 
-    init(eventLoop: EventLoop, maxSize: Int) {
+    public init(eventLoop: EventLoop, maxSize: Int) {
         self.queue = .init(initialCapacity: 8)
         self.queue.append(eventLoop.makePromise())
         self.eventLoop = eventLoop
@@ -73,7 +73,7 @@ public final class HBRequestBodyStreamer: HBStreamerProtocol {
 
     /// Feed a ByteBuffer to the request
     /// - Parameter result: Bytebuffer or end tag
-    func feed(_ result: FeedInput) {
+    public func feed(_ result: FeedInput) {
         self.eventLoop.assertInEventLoop()
 
         // queue most have at least one promise on it, or something has gone wrong
@@ -106,7 +106,7 @@ public final class HBRequestBodyStreamer: HBStreamerProtocol {
     /// - Parameter eventLoop: EventLoop to return future on
     /// - Returns: Returns an EventLoopFuture that will be fulfilled with array of ByteBuffers that has so far been fed to th request body
     ///     and whether we have consumed everything
-    public func consume(on eventLoop: EventLoop) -> EventLoopFuture<ConsumeOutput> {
+    public func consume(on eventLoop: EventLoop) -> EventLoopFuture<HBStreamerOutput> {
         self.eventLoop.flatSubmit {
             self.consume()
         }.hop(to: eventLoop)
@@ -176,7 +176,7 @@ public final class HBRequestBodyStreamer: HBStreamerProtocol {
     /// Consume what has been fed to the request
     /// - Returns: Returns an EventLoopFuture that will be fulfilled with array of ByteBuffers that has so far been fed to the request body
     ///     and whether we have consumed an end tag
-    func consume() -> EventLoopFuture<ConsumeOutput> {
+    func consume() -> EventLoopFuture<HBStreamerOutput> {
         self.eventLoop.assertInEventLoop()
         assert(self.queue.first != nil)
         let promise = self.queue.first!
@@ -226,14 +226,14 @@ public final class HBRequestBodyStreamer: HBStreamerProtocol {
 ///
 /// Required for the situation where the user wants to stream but has been provided
 /// with a single ByteBuffer
-final class HBByteBufferStreamer: HBStreamerProtocol {
+final class HBStaticStreamer: HBStreamerProtocol {
     var byteBuffer: ByteBuffer
 
     init(_ byteBuffer: ByteBuffer) {
         self.byteBuffer = byteBuffer
     }
 
-    func consume(on eventLoop: EventLoop) -> EventLoopFuture<HBRequestBodyStreamer.ConsumeOutput> {
+    func consume(on eventLoop: EventLoop) -> EventLoopFuture<HBStreamerOutput> {
         return eventLoop.submit {
             guard let output = self.byteBuffer.readSlice(length: self.byteBuffer.readableBytes) else {
                 return .end

--- a/Sources/HummingbirdCore/Request/ByteBufferStreamer.swift
+++ b/Sources/HummingbirdCore/Request/ByteBufferStreamer.swift
@@ -74,6 +74,18 @@ public final class HBByteBufferStreamer: HBStreamerProtocol {
     /// Feed a ByteBuffer to the request
     /// - Parameter result: Bytebuffer or end tag
     public func feed(_ result: FeedInput) {
+        if self.eventLoop.inEventLoop {
+            _feed(result)
+        } else {
+            self.eventLoop.execute {
+                self._feed(result)
+            }
+        }
+    }
+
+    /// Feed a ByteBuffer to the request
+    /// - Parameter result: Bytebuffer or end tag
+    private func _feed(_ result: FeedInput) {
         self.eventLoop.assertInEventLoop()
 
         // queue most have at least one promise on it, or something has gone wrong

--- a/Sources/HummingbirdCore/Request/RequestBody.swift
+++ b/Sources/HummingbirdCore/Request/RequestBody.swift
@@ -19,7 +19,7 @@ public enum HBRequestBody {
     /// Static ByteBuffer
     case byteBuffer(ByteBuffer?)
     /// ByteBuffer streamer
-    case stream(HBRequestBodyStreamer)
+    case stream(HBByteBufferStreamer)
 
     /// Return as ByteBuffer
     public var buffer: ByteBuffer? {
@@ -40,7 +40,7 @@ public enum HBRequestBody {
             guard let buffer = buffer else {
                 return nil
             }
-            return HBByteBufferStreamer(buffer)
+            return HBStaticStreamer(buffer)
         }
     }
 

--- a/Sources/HummingbirdCore/Response/ResponseBody.swift
+++ b/Sources/HummingbirdCore/Response/ResponseBody.swift
@@ -14,7 +14,7 @@
 
 import NIOCore
 
-/// Response body. Either static
+/// Response body. Can be a single ByteBuffer, a stream of ByteBuffers or empty
 public enum HBResponseBody {
     /// Body stored as a single ByteBuffer
     case byteBuffer(ByteBuffer)
@@ -29,20 +29,14 @@ public enum HBResponseBody {
     /// point is should return `'end`.
     ///
     /// - Parameter closure: Closure called whenever a new ByteBuffer is needed
-    public static func streamCallback(_ closure: @escaping (EventLoop) -> EventLoopFuture<HBResponseBody.StreamResult>) -> Self {
+    public static func streamCallback(_ closure: @escaping (EventLoop) -> EventLoopFuture<HBStreamerOutput>) -> Self {
         .stream(ResponseBodyStreamerCallback(closure: closure))
-    }
-
-    /// response body streamer result. Either a ByteBuffer or the end of the stream
-    public enum StreamResult {
-        case byteBuffer(ByteBuffer)
-        case end
     }
 }
 
-/// Object supplying bytebuffers for a response body
+/// Object supplying ByteBuffers for a response body
 public protocol HBResponseBodyStreamer {
-    func read(on eventLoop: EventLoop) -> EventLoopFuture<HBResponseBody.StreamResult>
+    func read(on eventLoop: EventLoop) -> EventLoopFuture<HBStreamerOutput>
 }
 
 extension HBResponseBodyStreamer {
@@ -68,9 +62,44 @@ extension HBResponseBodyStreamer {
     }
 }
 
+/// Response body that you can feed ByteBuffers
+public struct HBResponseByteBufferStreamer: HBResponseBodyStreamer {
+    let streamer: HBByteBufferStreamer
+
+    /// Create HBResponseByteBufferStreamer for streamer response bodies that request feeds
+    /// - Parameters:
+    ///   - eventLoop: EventLoop everything runs on
+    ///   - maxSize: Maximum size of data
+    public init(on eventLoop: EventLoop, maxSize: Int) {
+        self.streamer = .init(eventLoop: eventLoop, maxSize: maxSize)
+    }
+
+    /// Feed streamer a ByteBuffer or end of stream
+    /// - Parameter result: feed input (ByteBuffer of end of stream)
+    public func feed(_ result: HBByteBufferStreamer.FeedInput) {
+        streamer.feed(result)
+    }
+
+    /// Read ByteBuffer from streamer.
+    ///
+    /// This is used internally when serializing the response body
+    /// - Parameter eventLoop: EventLoop everything runs on
+    /// - Returns: Streamer output (ByteBuffer or end of stream)
+    public func read(on eventLoop: EventLoop) -> EventLoopFuture<HBStreamerOutput> {
+        return self.streamer.consume(on: eventLoop)
+    }
+}
+
 struct ResponseBodyStreamerCallback: HBResponseBodyStreamer {
-    let closure: (EventLoop) -> EventLoopFuture<HBResponseBody.StreamResult>
-    func read(on eventLoop: EventLoop) -> EventLoopFuture<HBResponseBody.StreamResult> {
+    /// Closure called whenever a new ByteBuffer is needed
+    let closure: (EventLoop) -> EventLoopFuture<HBStreamerOutput>
+
+    /// Read ByteBuffer from streamer.
+    ///
+    /// This is used internally when serializing the response body
+    /// - Parameter eventLoop: EventLoop everything runs on
+    /// - Returns: Streamer output (ByteBuffer or end of stream)
+    func read(on eventLoop: EventLoop) -> EventLoopFuture<HBStreamerOutput> {
         return self.closure(eventLoop)
     }
 }

--- a/Sources/HummingbirdCore/Response/ResponseBody.swift
+++ b/Sources/HummingbirdCore/Response/ResponseBody.swift
@@ -29,6 +29,16 @@ public enum HBResponseBody {
     /// point is should return `'end`.
     ///
     /// - Parameter closure: Closure called whenever a new ByteBuffer is needed
+    public static func stream(_ streamer: HBByteBufferStreamer) -> Self {
+        .stream(ResponseByteBufferStreamer(streamer: streamer))
+    }
+
+    /// Construct a `HBResponseBody` from a closure supplying `ByteBuffer`'s.
+    ///
+    /// This function should supply `.byteBuffer(ByteBuffer)` until there is no more data, at which
+    /// point is should return `'end`.
+    ///
+    /// - Parameter closure: Closure called whenever a new ByteBuffer is needed
     public static func streamCallback(_ closure: @escaping (EventLoop) -> EventLoopFuture<HBStreamerOutput>) -> Self {
         .stream(ResponseBodyStreamerCallback(closure: closure))
     }
@@ -63,29 +73,15 @@ extension HBResponseBodyStreamer {
 }
 
 /// Response body that you can feed ByteBuffers
-public struct HBResponseByteBufferStreamer: HBResponseBodyStreamer {
+struct ResponseByteBufferStreamer: HBResponseBodyStreamer {
     let streamer: HBByteBufferStreamer
-
-    /// Create HBResponseByteBufferStreamer for streamer response bodies that request feeds
-    /// - Parameters:
-    ///   - eventLoop: EventLoop everything runs on
-    ///   - maxSize: Maximum size of data
-    public init(on eventLoop: EventLoop, maxSize: Int) {
-        self.streamer = .init(eventLoop: eventLoop, maxSize: maxSize)
-    }
-
-    /// Feed streamer a ByteBuffer or end of stream
-    /// - Parameter result: feed input (ByteBuffer of end of stream)
-    public func feed(_ result: HBByteBufferStreamer.FeedInput) {
-        streamer.feed(result)
-    }
 
     /// Read ByteBuffer from streamer.
     ///
     /// This is used internally when serializing the response body
     /// - Parameter eventLoop: EventLoop everything runs on
     /// - Returns: Streamer output (ByteBuffer or end of stream)
-    public func read(on eventLoop: EventLoop) -> EventLoopFuture<HBStreamerOutput> {
+    func read(on eventLoop: EventLoop) -> EventLoopFuture<HBStreamerOutput> {
         return self.streamer.consume(on: eventLoop)
     }
 }

--- a/Tests/HummingbirdCoreTests/CoreTests+async.swift
+++ b/Tests/HummingbirdCoreTests/CoreTests+async.swift
@@ -49,7 +49,7 @@ final class HummingBirdCoreAsyncTests: XCTestCase {
         #endif
         struct Responder: HBHTTPResponder {
             func respond(to request: HBHTTPRequest, context: ChannelHandlerContext, onComplete: @escaping (Result<HBHTTPResponse, Error>) -> Void) {
-                let streamer = HBByteBufferStreamer(eventLoop: context.eventLoop, maxSize: 1024*2048)
+                let streamer = HBByteBufferStreamer(eventLoop: context.eventLoop, maxSize: 1024 * 2048)
                 Task {
                     do {
                         for try await buffer in request.body.stream!.sequence {

--- a/Tests/HummingbirdCoreTests/CoreTests+async.swift
+++ b/Tests/HummingbirdCoreTests/CoreTests+async.swift
@@ -42,22 +42,29 @@ final class HummingBirdCoreAsyncTests: XCTestCase {
         return ByteBufferAllocator().buffer(bytes: data)
     }
 
-    func testStreamBody() {
+    func testStreamBody() throws {
+        #if os(macOS)
+        // disable macOS tests in CI. GH Actions are currently running this when they shouldn't
+        guard ProcessInfo.processInfo.environment["CI"] != "true" else { throw XCTSkip() }
+        #endif
         struct Responder: HBHTTPResponder {
             func respond(to request: HBHTTPRequest, context: ChannelHandlerContext, onComplete: @escaping (Result<HBHTTPResponse, Error>) -> Void) {
-                let allocator = context.channel.allocator
+                let streamer = HBByteBufferStreamer(eventLoop: context.eventLoop, maxSize: 1024*2048)
                 Task {
-                    var responseBuffer = allocator.buffer(capacity: 0)
-                    for try await buffer in request.body.stream!.sequence {
-                        var buffer = buffer
-                        responseBuffer.writeBuffer(&buffer)
+                    do {
+                        for try await buffer in request.body.stream!.sequence {
+                            streamer.feed(.byteBuffer(buffer))
+                        }
+                        streamer.feed(.end)
+                    } catch {
+                        streamer.feed(.error(error))
                     }
-                    let response = HBHTTPResponse(
-                        head: .init(version: .init(major: 1, minor: 1), status: .ok),
-                        body: .byteBuffer(responseBuffer)
-                    )
-                    onComplete(.success(response))
                 }
+                let response = HBHTTPResponse(
+                    head: .init(version: .init(major: 1, minor: 1), status: .ok),
+                    body: .stream(streamer)
+                )
+                onComplete(.success(response))
             }
         }
         let server = HBHTTPServer(group: Self.eventLoopGroup, configuration: .init(address: .hostname(port: 0), maxStreamingBufferSize: 256 * 1024))

--- a/Tests/HummingbirdCoreTests/CoreTests.swift
+++ b/Tests/HummingbirdCoreTests/CoreTests.swift
@@ -209,7 +209,7 @@ class HummingBirdCoreTests: XCTestCase {
     func testStreamBody2() {
         struct Responder: HBHTTPResponder {
             func respond(to request: HBHTTPRequest, context: ChannelHandlerContext, onComplete: @escaping (Result<HBHTTPResponse, Error>) -> Void) {
-                let streamer = HBResponseByteBufferStreamer(on: context.eventLoop, maxSize: 2048*1024)
+                let streamer = HBByteBufferStreamer(eventLoop: context.eventLoop, maxSize: 2048*1024)
                 request.body.stream?.consumeAll(on: context.eventLoop) { buffer in
                     streamer.feed(.byteBuffer(buffer))
                     return context.eventLoop.makeSucceededVoidFuture()

--- a/Tests/HummingbirdCoreTests/CoreTests.swift
+++ b/Tests/HummingbirdCoreTests/CoreTests.swift
@@ -206,6 +206,45 @@ class HummingBirdCoreTests: XCTestCase {
         XCTAssertNoThrow(try future.wait())
     }
 
+    func testStreamBody2() {
+        struct Responder: HBHTTPResponder {
+            func respond(to request: HBHTTPRequest, context: ChannelHandlerContext, onComplete: @escaping (Result<HBHTTPResponse, Error>) -> Void) {
+                let streamer = HBResponseByteBufferStreamer(on: context.eventLoop, maxSize: 2048*1024)
+                request.body.stream?.consumeAll(on: context.eventLoop) { buffer in
+                    streamer.feed(.byteBuffer(buffer))
+                    return context.eventLoop.makeSucceededVoidFuture()
+                }
+                .flatMapErrorThrowing { error in
+                    streamer.feed(.error(error))
+                    throw error
+                }
+                .whenComplete { result in
+                    streamer.feed(.end)
+                }
+                let response = HBHTTPResponse(
+                    head: .init(version: .init(major: 1, minor: 1), status: .ok),
+                    body: .stream(streamer)
+                )
+                return onComplete(.success(response))
+            }
+        }
+        let server = HBHTTPServer(group: Self.eventLoopGroup, configuration: .init(address: .hostname(port: 0), maxStreamingBufferSize: 256 * 1024))
+        XCTAssertNoThrow(try server.start(responder: Responder()).wait())
+        defer { XCTAssertNoThrow(try server.stop().wait()) }
+
+        let client = HBXCTClient(host: "localhost", port: server.port!, eventLoopGroupProvider: .createNew)
+        client.connect()
+        defer { XCTAssertNoThrow(try client.syncShutdown()) }
+
+        let buffer = self.randomBuffer(size: 1_140_000)
+        let future = client.post("/", body: buffer)
+            .flatMapThrowing { response in
+                let body = try XCTUnwrap(response.body)
+                XCTAssertEqual(body, buffer)
+            }
+        XCTAssertNoThrow(try future.wait())
+    }
+
     func testStreamBodySlowProcess() {
         struct Responder: HBHTTPResponder {
             func respond(to request: HBHTTPRequest, context: ChannelHandlerContext, onComplete: @escaping (Result<HBHTTPResponse, Error>) -> Void) {

--- a/Tests/HummingbirdCoreTests/CoreTests.swift
+++ b/Tests/HummingbirdCoreTests/CoreTests.swift
@@ -209,7 +209,7 @@ class HummingBirdCoreTests: XCTestCase {
     func testStreamBody2() {
         struct Responder: HBHTTPResponder {
             func respond(to request: HBHTTPRequest, context: ChannelHandlerContext, onComplete: @escaping (Result<HBHTTPResponse, Error>) -> Void) {
-                let streamer = HBByteBufferStreamer(eventLoop: context.eventLoop, maxSize: 2048*1024)
+                let streamer = HBByteBufferStreamer(eventLoop: context.eventLoop, maxSize: 2048 * 1024)
                 request.body.stream?.consumeAll(on: context.eventLoop) { buffer in
                     streamer.feed(.byteBuffer(buffer))
                     return context.eventLoop.makeSucceededVoidFuture()
@@ -218,7 +218,7 @@ class HummingBirdCoreTests: XCTestCase {
                     streamer.feed(.error(error))
                     throw error
                 }
-                .whenComplete { result in
+                .whenComplete { _ in
                     streamer.feed(.end)
                 }
                 let response = HBHTTPResponse(


### PR DESCRIPTION
Currently the response body streamer uses a callback to retrieve ByteBuffers
This PR generalizes the `HBRequestBodyStreamer` so it can be used for both requests and responses. It has also been renamed to `HBByteBufferStreamer`.
Create a streamer and then set it as the response body
```swift
let streamer = HBByteBufferStreamer(eventLoop: context.eventLoop, maxSize: 2048*1024)
streamer.feed(.byteBuffer(buffer))
streamer.feed(.end)
let response = HBHTTPResponse(
   head: .init(version: .init(major: 1, minor: 1), status: .ok),
   body: .stream(streamer)
)
```

 