### PR TITLE
Added context details to assertion error message

### DIFF
--- a/Sources/HummingbirdCore/Server/HTTPServerHandler.swift
+++ b/Sources/HummingbirdCore/Server/HTTPServerHandler.swift
@@ -104,7 +104,7 @@ final class HBHTTPServerHandler: ChannelDuplexHandler, RemovableChannelHandler {
             break
 
         default:
-            assertionFailure("Should not get here")
+            assertionFailure("Should not get here!\nPart: \(part)\nState: \(self.state)")
             context.close(promise: nil)
         }
     }


### PR DESCRIPTION
When HTTPServerHandler.channelRead finds itself in a unexpected combination of inbound data and channel state, this change makes the error message print the state and the part to make troubleshooting easier. Changes only the printed error message, no changes to functionality.

In response to  #41 