### PR TITLE
Add Idle state handler configuration

### DIFF
--- a/Sources/HummingbirdCore/Server/HTTPChannelHandlers.swift
+++ b/Sources/HummingbirdCore/Server/HTTPChannelHandlers.swift
@@ -17,8 +17,13 @@ import NIOCore
 /// Stores channel handlers used in HTTP server
 struct HBHTTPChannelHandlers {
     /// Initialize `HBHTTPChannelHandlers`
-    public init() {
+    init() {
         self.handlers = []
+    }
+
+    /// Initialize `HBHTTPChannelHandlers`
+    init(_ initialHandlers: [RemovableChannelHandler]) {
+        self.handlers = initialHandlers.map { handler in return { handler } }
     }
 
     /// Add autoclosure that creates a ChannelHandler

--- a/Sources/HummingbirdCore/Server/HTTPChannelHandlers.swift
+++ b/Sources/HummingbirdCore/Server/HTTPChannelHandlers.swift
@@ -21,11 +21,6 @@ struct HBHTTPChannelHandlers {
         self.handlers = []
     }
 
-    /// Initialize `HBHTTPChannelHandlers`
-    init(_ initialHandlers: [RemovableChannelHandler]) {
-        self.handlers = initialHandlers.map { handler in return { handler } }
-    }
-
     /// Add autoclosure that creates a ChannelHandler
     public mutating func addHandler(_ handler: @autoclosure @escaping () -> RemovableChannelHandler) {
         self.handlers.append(handler)

--- a/Sources/HummingbirdCore/Server/HTTPServer+Configuration.swift
+++ b/Sources/HummingbirdCore/Server/HTTPServer+Configuration.swift
@@ -12,6 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+import NIOCore
+
 extension HBHTTPServer {
     /// HTTP server configuration
     public struct Configuration {
@@ -31,6 +33,8 @@ extension HBHTTPServer {
         public let tcpNoDelay: Bool
         /// Pipelining ensures that only one http request is processed at one time
         public let withPipeliningAssistance: Bool
+        /// Idle state handler setup.
+        public let idleReadTimeout: TimeAmount?
         #if canImport(Network)
         /// TLS options for NIO Transport services
         public let tlsOptions: TSTLSOptions
@@ -53,7 +57,8 @@ extension HBHTTPServer {
             backlog: Int = 256,
             reuseAddress: Bool = true,
             tcpNoDelay: Bool = true,
-            withPipeliningAssistance: Bool = true
+            withPipeliningAssistance: Bool = true,
+            idleReadTimeout: TimeAmount? = nil
         ) {
             self.address = address
             self.serverName = serverName
@@ -63,6 +68,7 @@ extension HBHTTPServer {
             self.reuseAddress = reuseAddress
             self.tcpNoDelay = tcpNoDelay
             self.withPipeliningAssistance = withPipeliningAssistance
+            self.idleReadTimeout = idleReadTimeout
             #if canImport(Network)
             self.tlsOptions = .none
             #endif
@@ -85,6 +91,7 @@ extension HBHTTPServer {
             maxStreamingBufferSize: Int = 1 * 1024 * 1024,
             reuseAddress: Bool = true,
             withPipeliningAssistance: Bool = true,
+            idleReadTimeout: TimeAmount? = nil,
             tlsOptions: TSTLSOptions
         ) {
             self.address = address
@@ -95,6 +102,7 @@ extension HBHTTPServer {
             self.reuseAddress = reuseAddress
             self.tcpNoDelay = true
             self.withPipeliningAssistance = withPipeliningAssistance
+            self.idleReadTimeout = idleReadTimeout
             self.tlsOptions = tlsOptions
         }
         #endif

--- a/Sources/HummingbirdCore/Server/HTTPServer+Configuration.swift
+++ b/Sources/HummingbirdCore/Server/HTTPServer+Configuration.swift
@@ -15,6 +15,19 @@
 import NIOCore
 
 extension HBHTTPServer {
+    /// Idle state handlder configuration
+    public struct IdleStateHandlerConfiguration {
+        /// timeout when reading a request
+        let readTimeout: TimeAmount
+        /// timeout since last writing a response
+        let writeTimeout: TimeAmount
+
+        public init(readTimeout: TimeAmount = .seconds(30), writeTimeout: TimeAmount = .minutes(3)) {
+            self.readTimeout = readTimeout
+            self.writeTimeout = writeTimeout
+        }
+    }
+
     /// HTTP server configuration
     public struct Configuration {
         /// Bind address for server
@@ -34,7 +47,7 @@ extension HBHTTPServer {
         /// Pipelining ensures that only one http request is processed at one time
         public let withPipeliningAssistance: Bool
         /// Idle state handler setup.
-        public let idleReadTimeout: TimeAmount?
+        public let idleTimeoutConfiguration: IdleStateHandlerConfiguration?
         #if canImport(Network)
         /// TLS options for NIO Transport services
         public let tlsOptions: TSTLSOptions
@@ -58,7 +71,7 @@ extension HBHTTPServer {
             reuseAddress: Bool = true,
             tcpNoDelay: Bool = true,
             withPipeliningAssistance: Bool = true,
-            idleReadTimeout: TimeAmount? = nil
+            idleTimeoutConfiguration: IdleStateHandlerConfiguration? = nil
         ) {
             self.address = address
             self.serverName = serverName
@@ -68,7 +81,7 @@ extension HBHTTPServer {
             self.reuseAddress = reuseAddress
             self.tcpNoDelay = tcpNoDelay
             self.withPipeliningAssistance = withPipeliningAssistance
-            self.idleReadTimeout = idleReadTimeout
+            self.idleTimeoutConfiguration = idleTimeoutConfiguration
             #if canImport(Network)
             self.tlsOptions = .none
             #endif
@@ -91,7 +104,7 @@ extension HBHTTPServer {
             maxStreamingBufferSize: Int = 1 * 1024 * 1024,
             reuseAddress: Bool = true,
             withPipeliningAssistance: Bool = true,
-            idleReadTimeout: TimeAmount? = nil,
+            idleTimeoutConfiguration: IdleStateHandlerConfiguration? = nil,
             tlsOptions: TSTLSOptions
         ) {
             self.address = address
@@ -102,7 +115,7 @@ extension HBHTTPServer {
             self.reuseAddress = reuseAddress
             self.tcpNoDelay = true
             self.withPipeliningAssistance = withPipeliningAssistance
-            self.idleReadTimeout = idleReadTimeout
+            self.idleTimeoutConfiguration = idleTimeoutConfiguration
             self.tlsOptions = tlsOptions
         }
         #endif

--- a/Sources/HummingbirdCore/Server/HTTPServer.swift
+++ b/Sources/HummingbirdCore/Server/HTTPServer.swift
@@ -48,7 +48,7 @@ public final class HBHTTPServer {
         self.eventLoopGroup = group
         self.configuration = configuration
         self.quiesce = nil
-        self.childChannelHandlers = .init()
+        self.childChannelHandlers = configuration.idleReadTimeout.map { .init([IdleStateHandler(readTimeout: $0)]) } ?? .init()
         // defaults to HTTP1
         self.httpChannelInitializer = HTTP1ChannelInitializer()
     }

--- a/Sources/HummingbirdCore/Server/HTTPServer.swift
+++ b/Sources/HummingbirdCore/Server/HTTPServer.swift
@@ -53,9 +53,14 @@ public final class HBHTTPServer {
         self.childChannelHandlers = .init()
         // defaults to HTTP1
         self.httpChannelInitializer = HTTP1ChannelInitializer()
-        // add idle read handlers
-        if let idleReadTimeout = configuration.idleReadTimeout {
-            self.childChannelHandlers.addHandler(IdleStateHandler(readTimeout: idleReadTimeout))
+        // add idle read, write handlers
+        if let idleTimeoutConfiguration = configuration.idleTimeoutConfiguration {
+            self.childChannelHandlers.addHandler(
+                IdleStateHandler(
+                    readTimeout: idleTimeoutConfiguration.readTimeout,
+                    writeTimeout: idleTimeoutConfiguration.writeTimeout
+                )
+            )
         }
     }
 

--- a/Sources/HummingbirdCore/Server/HTTPServerHandler.swift
+++ b/Sources/HummingbirdCore/Server/HTTPServerHandler.swift
@@ -256,6 +256,13 @@ final class HBHTTPServerHandler: ChannelDuplexHandler, RemovableChannelHandler {
                 self.close(context: context)
             }
 
+        case let evt as IdleStateHandler.IdleStateEvent where evt == .write:
+            // if we get an idle write event and are not currently processing a request
+            if self.requestsInProgress == 0 {
+                self.responder.logger.trace("Idle write timeout, so close channel")
+                self.close(context: context)
+            }
+
         default:
             self.responder.logger.debug("Unhandled event \(event)")
             context.fireUserInboundEventTriggered(event)

--- a/Sources/HummingbirdCore/Server/HTTPServerHandler.swift
+++ b/Sources/HummingbirdCore/Server/HTTPServerHandler.swift
@@ -247,6 +247,11 @@ final class HBHTTPServerHandler: ChannelDuplexHandler, RemovableChannelHandler {
                 context.close(promise: nil)
             }
 
+        case let evt as IdleStateHandler.IdleStateEvent where evt == .read:
+            if case .idle = self.state {
+                context.close(promise: nil)
+            }
+
         default:
             self.responder.logger.debug("Unhandled event \(event)")
             context.fireUserInboundEventTriggered(event)

--- a/Sources/HummingbirdCoreXCT/XCTClient+types.swift
+++ b/Sources/HummingbirdCoreXCT/XCTClient+types.swift
@@ -24,6 +24,7 @@ extension HBXCTClient {
         case noResponse
         case tlsSetupFailed
         case readTimeout
+        case connectionNotOpen
     }
 
     public struct Request {

--- a/Sources/HummingbirdCoreXCT/XCTClient.swift
+++ b/Sources/HummingbirdCoreXCT/XCTClient.swift
@@ -239,6 +239,20 @@ public class HBXCTClient {
         }
     }
 
+    func userInboundEventTriggered(context: ChannelHandlerContext, event: Any) {
+        switch event {
+        case let evt as ChannelEvent where evt == .inputClosed:
+            context.close(promise: nil)
+
+        default:
+            context.fireUserInboundEventTriggered(event)
+        }
+    }
+
+    func errorCaught(context: ChannelHandlerContext, error: Error) {
+        context.close(promise: nil)
+    }
+
     /// HTTP Task structure
     private struct HTTPTask {
         let request: HBXCTClient.Request

--- a/Sources/HummingbirdCoreXCT/XCTClient.swift
+++ b/Sources/HummingbirdCoreXCT/XCTClient.swift
@@ -98,6 +98,10 @@ public class HBXCTClient {
 
     /// shutdown client
     public func syncShutdown() throws {
+        do {
+            try self.close().wait()
+        } catch HBXCTClient.Error.connectionNotOpen {
+        } catch ChannelError.alreadyClosed {}
         if case .createNew = self.eventLoopGroupProvider {
             try self.eventLoopGroup.syncShutdownGracefully()
         }
@@ -140,6 +144,13 @@ public class HBXCTClient {
             let task = HTTPTask(request: self.cleanupRequest(request), responsePromise: promise.promise)
             channel.writeAndFlush(task, promise: nil)
             return promise.futureResult
+        }
+    }
+
+    public func close() -> EventLoopFuture<Void> {
+        self.channelPromise.completeWith(.failure(HBXCTClient.Error.connectionNotOpen))
+        return self.channelPromise.futureResult.flatMap { channel in
+            channel.close()
         }
     }
 
@@ -239,20 +250,6 @@ public class HBXCTClient {
         }
     }
 
-    func userInboundEventTriggered(context: ChannelHandlerContext, event: Any) {
-        switch event {
-        case let evt as ChannelEvent where evt == .inputClosed:
-            context.close(promise: nil)
-
-        default:
-            context.fireUserInboundEventTriggered(event)
-        }
-    }
-
-    func errorCaught(context: ChannelHandlerContext, error: Error) {
-        context.close(promise: nil)
-    }
-
     /// HTTP Task structure
     private struct HTTPTask {
         let request: HBXCTClient.Request
@@ -295,10 +292,6 @@ public class HBXCTClient {
         func userInboundEventTriggered(context: ChannelHandlerContext, event: Any) {
             switch event {
             case let evt as IdleStateHandler.IdleStateEvent where evt == .read:
-                // The remote peer half-closed the channel. At this time, any
-                // outstanding response will be written before the channel is
-                // closed, and if we are idle we will close the channel immediately.
-                // if error caught, pass to all tasks in progress and close channel
                 while let task = self.queue.popFirst() {
                     task.responsePromise.fail(HBXCTClient.Error.readTimeout)
                 }


### PR DESCRIPTION
Add configuration to HBServer that enables an IdleStateHandler
The HBServerHandler will then close the connection 
- if we get a read timeout in the middle of loading a request
- if we get a write timeout when not processing any requests

Other fixes include

- pass error to streaming body if closing connection
- Add XCTClient.close()