### PR TITLE
Allow adding of upgraders to channel initialisers

### DIFF
--- a/Sources/HummingbirdCore/Server/ChannelInitializer.swift
+++ b/Sources/HummingbirdCore/Server/ChannelInitializer.swift
@@ -23,6 +23,14 @@ public protocol HBChannelInitializer {
     ///   - childHandlers: Channel handlers to add
     ///   - configuration: server configuration
     func initialize(channel: Channel, childHandlers: [RemovableChannelHandler], configuration: HBHTTPServer.Configuration) -> EventLoopFuture<Void>
+
+    ///  Add protocol upgrader to channel initializer
+    /// - Parameter upgrader: HTTP server protocol upgrader to add
+    mutating func addProtocolUpgrader(_ upgrader: HTTPServerProtocolUpgrader)
+}
+
+extension HBChannelInitializer {
+    public mutating func addProtocolUpgrader(_: HTTPServerProtocolUpgrader) {}
 }
 
 /// Setup child channel for HTTP1
@@ -55,5 +63,11 @@ public struct HTTP1ChannelInitializer: HBChannelInitializer {
         }
     }
 
-    let upgraders: [HTTPServerProtocolUpgrader]
+    ///  Add protocol upgrader to channel initializer
+    /// - Parameter upgrader: HTTP server protocol upgrader to add
+    public mutating func addProtocolUpgrader(_ upgrader: HTTPServerProtocolUpgrader) {
+        self.upgraders.append(upgrader)
+    }
+
+    var upgraders: [HTTPServerProtocolUpgrader]
 }

--- a/Sources/HummingbirdHTTP2/ChannelInitializer.swift
+++ b/Sources/HummingbirdHTTP2/ChannelInitializer.swift
@@ -14,6 +14,7 @@
 
 import HummingbirdCore
 import NIOCore
+import NIOHTTP1
 import NIOHTTP2
 import NIOSSL
 
@@ -32,7 +33,7 @@ struct HTTP2ChannelInitializer: HBChannelInitializer {
 
 /// HTTP2 upgrade channel initializer
 struct HTTP2UpgradeChannelInitializer: HBChannelInitializer {
-    let http1 = HTTP1ChannelInitializer()
+    var http1 = HTTP1ChannelInitializer()
     let http2 = HTTP2ChannelInitializer()
 
     func initialize(channel: Channel, childHandlers: [RemovableChannelHandler], configuration: HBHTTPServer.Configuration) -> EventLoopFuture<Void> {
@@ -44,5 +45,11 @@ struct HTTP2UpgradeChannelInitializer: HBChannelInitializer {
                 http1.initialize(channel: channel, childHandlers: childHandlers, configuration: configuration)
             }
         )
+    }
+
+    ///  Add protocol upgrader to channel initializer
+    /// - Parameter upgrader: HTTP server protocol upgrader to add
+    public mutating func addProtocolUpgrader(_ upgrader: HTTPServerProtocolUpgrader) {
+        self.http1.addProtocolUpgrader(upgrader)
     }
 }


### PR DESCRIPTION
Instead of requiring the channel initialiser to be replaced.

Will allow us to  fix issue where adding websocket upgrade would remove http2 upgrade