### PR TITLE
ByteBufferStreamer: Only create promises when consumes run out of input

### DIFF
--- a/Sources/HummingbirdCore/Request/ByteBufferStreamer.swift
+++ b/Sources/HummingbirdCore/Request/ByteBufferStreamer.swift
@@ -16,7 +16,7 @@ import Foundation
 import NIOCore
 
 /// Values returned when we consume the contents of the streamer
-public enum HBStreamerOutput: HBSendable {
+public enum HBStreamerOutput: HBSendable, Equatable {
     case byteBuffer(ByteBuffer)
     case end
 }

--- a/Sources/HummingbirdCore/Request/RequestBody.swift
+++ b/Sources/HummingbirdCore/Request/RequestBody.swift
@@ -53,7 +53,7 @@ public enum HBRequestBody: HBSendable {
         case .byteBuffer(let buffer):
             return eventLoop.makeSucceededFuture(buffer)
         case .stream(let streamer):
-            return streamer.consumeAll(maxSize: .max).hop(to: eventLoop)
+            return streamer.collate(maxSize: .max).hop(to: eventLoop)
         }
     }
 
@@ -67,7 +67,7 @@ public enum HBRequestBody: HBSendable {
         case .byteBuffer(let buffer):
             return eventLoop.makeSucceededFuture(buffer)
         case .stream(let streamer):
-            return streamer.consumeAll(maxSize: maxSize).hop(to: eventLoop)
+            return streamer.collate(maxSize: maxSize).hop(to: eventLoop)
         }
     }
 }
@@ -109,9 +109,9 @@ extension HBRequestBody {
             return buffer
         case .stream(let streamer):
             if !streamer.eventLoop.inEventLoop {
-                return try await streamer.eventLoop.flatSubmit { streamer.consumeAll(maxSize: maxSize) }.get()
+                return try await streamer.eventLoop.flatSubmit { streamer.collate(maxSize: maxSize) }.get()
             } else {
-                return try await streamer.consumeAll(maxSize: maxSize).get()
+                return try await streamer.collate(maxSize: maxSize).get()
             }
         }
     }

--- a/Tests/HummingbirdCoreTests/StreamerTests.swift
+++ b/Tests/HummingbirdCoreTests/StreamerTests.swift
@@ -248,6 +248,19 @@ class ByteBufferStreamerTests: XCTestCase {
         }
     }
 
+    func testCallingConsumeAfterEnd() throws {
+        let buffer = self.randomBuffer(size: 1)
+        let eventLoop = self.elg.next()
+        let streamer = HBByteBufferStreamer(eventLoop: eventLoop, maxSize: 32 * 1024)
+        streamer.feed(.byteBuffer(buffer))
+        streamer.feed(.end)
+        _ = try streamer.consume(on: eventLoop).wait()
+        let end1 = try streamer.consume(on: eventLoop).wait()
+        let end2 = try streamer.consume(on: eventLoop).wait()
+        XCTAssertEqual(end1, .end)
+        XCTAssertEqual(end2, .end)
+    }
+
     /// test error is propagated
     func testError() throws {
         struct MyError: Error {}

--- a/Tests/HummingbirdCoreTests/StreamerTests.swift
+++ b/Tests/HummingbirdCoreTests/StreamerTests.swift
@@ -211,7 +211,7 @@ class ByteBufferStreamerTests: XCTestCase {
         var buffer = originalBuffer
         let eventLoop = self.elg.next()
         let streamer = HBByteBufferStreamer(eventLoop: eventLoop, maxSize: 1024 * 1024, maxStreamingBufferSize: 64 * 1024)
-        let finalBuffer = try eventLoop.flatSubmit {
+        let finalBuffer = try eventLoop.flatSubmit { () -> EventLoopFuture<ByteBuffer> in
             var finalBuffer = ByteBufferAllocator().buffer(capacity: 20000)
             var consumeRequests: [EventLoopFuture<HBStreamerOutput>] = (0..<5).map { _ in streamer.consume() }
             while let slice = buffer.readSlice(length: 2000) {


### PR DESCRIPTION
When consuming buffers, if there are no buffers on the queue, then create promise and add to waiting queue
When feeding buffers if there are promises in the waiting queue succeed the first of those promises with the buffer, otherwise just add buffer to buffer queue.

This change allows for multiple consumers of the ByteBufferStreamer. 

Also fixed issue where calling consume again after a consume has already returned an `.end` would crash 