### PR TITLE
Deprecate HBSendable

### DIFF
--- a/Sources/HummingbirdCore/AsyncAwaitSupport/RequestBodyStreamer+async.swift
+++ b/Sources/HummingbirdCore/AsyncAwaitSupport/RequestBodyStreamer+async.swift
@@ -46,7 +46,7 @@ extension HBStaticStreamer {
 
 /// AsyncSequence providing ByteBuffers from a request body stream
 @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
-public struct HBRequestBodyStreamerSequence: AsyncSequence {
+public struct HBRequestBodyStreamerSequence: AsyncSequence, Sendable {
     public typealias Element = ByteBuffer
 
     let streamer: HBStreamerProtocol

--- a/Sources/HummingbirdCore/AsyncAwaitSupport/Sendable.swift
+++ b/Sources/HummingbirdCore/AsyncAwaitSupport/Sendable.swift
@@ -15,8 +15,5 @@
 import NIOCore
 import NIOHTTP1
 
-#if swift(>=5.6)
+@available(*, deprecated, renamed: "Sendable")
 public typealias HBSendable = Swift.Sendable
-#else
-public typealias HBSendable = Any
-#endif

--- a/Sources/HummingbirdCore/Error/HTTPError.swift
+++ b/Sources/HummingbirdCore/Error/HTTPError.swift
@@ -16,7 +16,7 @@ import NIOCore
 import NIOHTTP1
 
 /// Default HTTP error. Provides an HTTP status and a message is so desired
-public struct HBHTTPError: Error, HBHTTPResponseError, HBSendable {
+public struct HBHTTPError: Error, HBHTTPResponseError, Sendable {
     /// status code for the error
     public let status: HTTPResponseStatus
     /// any addiitional headers required

--- a/Sources/HummingbirdCore/Request/ByteBufferStreamer.swift
+++ b/Sources/HummingbirdCore/Request/ByteBufferStreamer.swift
@@ -16,13 +16,13 @@ import Foundation
 import NIOCore
 
 /// Values returned when we consume the contents of the streamer
-public enum HBStreamerOutput: HBSendable, Equatable {
+public enum HBStreamerOutput: Sendable, Equatable {
     case byteBuffer(ByteBuffer)
     case end
 }
 
 /// Protocol for objects providing a stream of ByteBuffers
-public protocol HBStreamerProtocol: HBSendable {
+public protocol HBStreamerProtocol: Sendable {
     /// Consume what has been fed to the streamer
     /// - Parameter eventLoop: EventLoop to return future on
     /// - Returns: Returns an EventLoopFuture that will be fulfilled with array of ByteBuffers that has so far been fed to the request body

--- a/Sources/HummingbirdCore/Request/ByteBufferStreamer.swift
+++ b/Sources/HummingbirdCore/Request/ByteBufferStreamer.swift
@@ -46,7 +46,7 @@ public final class HBByteBufferStreamer: HBStreamerProtocol {
     }
 
     /// Values we can feed the streamer with
-    public enum FeedInput {
+    public enum FeedInput: Sendable {
         case byteBuffer(ByteBuffer)
         case error(Error)
         case end

--- a/Sources/HummingbirdCore/Request/Request.swift
+++ b/Sources/HummingbirdCore/Request/Request.swift
@@ -16,7 +16,7 @@ import NIOCore
 import NIOHTTP1
 
 /// HTTP request
-public struct HBHTTPRequest: HBSendable {
+public struct HBHTTPRequest: Sendable {
     public var head: HTTPRequestHead
     public var body: HBRequestBody
 }

--- a/Sources/HummingbirdCore/Request/RequestBody.swift
+++ b/Sources/HummingbirdCore/Request/RequestBody.swift
@@ -15,7 +15,7 @@
 import NIOCore
 
 /// Request Body. Either a ByteBuffer or a ByteBuffer streamer
-public enum HBRequestBody: HBSendable {
+public enum HBRequestBody: Sendable {
     /// Static ByteBuffer
     case byteBuffer(ByteBuffer?)
     /// ByteBuffer streamer

--- a/Sources/HummingbirdCore/Response/Response.swift
+++ b/Sources/HummingbirdCore/Response/Response.swift
@@ -16,7 +16,7 @@ import NIOCore
 import NIOHTTP1
 
 /// HTTP response
-public struct HBHTTPResponse: HBSendable {
+public struct HBHTTPResponse: Sendable {
     public var head: HTTPResponseHead
     public var body: HBResponseBody
 

--- a/Sources/HummingbirdCore/Response/ResponseBody.swift
+++ b/Sources/HummingbirdCore/Response/ResponseBody.swift
@@ -18,7 +18,7 @@ import NIOCore
 public typealias HBStreamCallback = @Sendable (EventLoop) -> EventLoopFuture<HBStreamerOutput>
 
 /// Response body. Can be a single ByteBuffer, a stream of ByteBuffers or empty
-public enum HBResponseBody: HBSendable {
+public enum HBResponseBody: Sendable {
     /// Body stored as a single ByteBuffer
     case byteBuffer(ByteBuffer)
     /// Streamer object supplying byte buffers
@@ -75,7 +75,7 @@ extension HBResponseBody: CustomStringConvertible {
 }
 
 /// Object supplying ByteBuffers for a response body
-public protocol HBResponseBodyStreamer: HBSendable {
+public protocol HBResponseBodyStreamer: Sendable {
     func read(on eventLoop: EventLoop) -> EventLoopFuture<HBStreamerOutput>
 }
 

--- a/Sources/HummingbirdCore/Server/HTTPServer+Configuration.swift
+++ b/Sources/HummingbirdCore/Server/HTTPServer+Configuration.swift
@@ -16,7 +16,7 @@ import NIOCore
 
 extension HBHTTPServer {
     /// Idle state handlder configuration
-    public struct IdleStateHandlerConfiguration {
+    public struct IdleStateHandlerConfiguration: Sendable {
         /// timeout when reading a request
         let readTimeout: TimeAmount
         /// timeout since last writing a response

--- a/Sources/HummingbirdCore/Server/TSTLSOptions.swift
+++ b/Sources/HummingbirdCore/Server/TSTLSOptions.swift
@@ -17,7 +17,7 @@ import Foundation
 import Network
 
 /// Wrapper for NIO transport services TLS options
-public struct TSTLSOptions {
+public struct TSTLSOptions: Sendable {
     @available(macOS 10.14, iOS 12, tvOS 12, *)
     public enum ServerIdentity {
         case secIdentity(SecIdentity)


### PR DESCRIPTION
Not sure how I missed this one when going up to Swift 5.6, anyway don't really want anyone using `HBSendable`
I also added Sendable conformance to some other public symbols I missed