### PR TITLE
Wrap HBByteBufferStreamer internals in NIOLoopBound

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-log.git", from: "1.4.0"),
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.41.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.49.0"),
         .package(url: "https://github.com/apple/swift-nio-extras.git", from: "1.7.0"),
         .package(url: "https://github.com/apple/swift-nio-http2.git", from: "1.20.0"),
         .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.14.0"),

--- a/Sources/HummingbirdCore/AsyncAwaitSupport/RequestBodyStreamer+async.swift
+++ b/Sources/HummingbirdCore/AsyncAwaitSupport/RequestBodyStreamer+async.swift
@@ -24,9 +24,7 @@ extension HBStreamerProtocol {
 extension HBByteBufferStreamer {
     /// Consume what has been fed to the request so far
     public func consume() async throws -> HBStreamerOutput {
-        return try await self.eventLoop.flatSubmit {
-            self.consume()
-        }.get()
+        try await self.consume().get()
     }
 }
 

--- a/Sources/HummingbirdCore/Request/ByteBufferStreamer.swift
+++ b/Sources/HummingbirdCore/Request/ByteBufferStreamer.swift
@@ -335,7 +335,7 @@ public final class HBByteBufferStreamer: HBStreamerProtocol, Sendable {
     /// Feed a ByteBuffer to the request, while applying back pressure
     /// - Parameter result: Bytebuffer or end tag
     public func feed(buffer: ByteBuffer) -> EventLoopFuture<Void> {
-        self.state.onLoop { state, eventLoop in
+        self.state.runOnLoop { state, eventLoop in
             state.feed(buffer: buffer, eventLoop: eventLoop)
         }
     }
@@ -343,7 +343,7 @@ public final class HBByteBufferStreamer: HBStreamerProtocol, Sendable {
     /// Feed a ByteBuffer to the request
     /// - Parameter result: Bytebuffer or end tag
     public func feed(_ result: FeedInput) {
-        self.state.onLoop { state, eventLoop in
+        self.state.runOnLoop { state, eventLoop in
             state.feed(result, eventLoop: eventLoop)
         }
     }
@@ -354,7 +354,7 @@ public final class HBByteBufferStreamer: HBStreamerProtocol, Sendable {
     /// - Returns: Returns an EventLoopFuture that will be fulfilled with array of ByteBuffers that has so far been fed to th request body
     ///     and whether we have consumed everything
     public func consume() -> EventLoopFuture<HBStreamerOutput> {
-        self.state.onLoop { state, eventLoop in
+        self.state.runOnLoop { state, eventLoop in
             state.consume(eventLoop: eventLoop)
         }
     }
@@ -365,7 +365,7 @@ public final class HBByteBufferStreamer: HBStreamerProtocol, Sendable {
     /// - Returns: Returns an EventLoopFuture that will be fulfilled with array of ByteBuffers that has so far been fed to th request body
     ///     and whether we have consumed everything
     public func consume(on eventLoop: EventLoop) -> EventLoopFuture<HBStreamerOutput> {
-        self.state.onLoop { state, eventLoop in
+        self.state.runOnLoop { state, eventLoop in
             state.consume(eventLoop: eventLoop)
         }.hop(to: eventLoop)
     }
@@ -376,7 +376,7 @@ public final class HBByteBufferStreamer: HBStreamerProtocol, Sendable {
     ///   - eventLoop: EventLoop to run on
     ///   - process: Closure to call to process ByteBuffer
     public func consumeAll(_ process: @escaping (ByteBuffer) -> EventLoopFuture<Void>) -> EventLoopFuture<Void> {
-        self.state.onLoop { state, eventLoop in
+        self.state.runOnLoop { state, eventLoop in
             state.consumeAll(on: eventLoop, process)
         }
     }
@@ -387,7 +387,7 @@ public final class HBByteBufferStreamer: HBStreamerProtocol, Sendable {
     ///   - eventLoop: EventLoop to run on
     ///   - process: Closure to call to process ByteBuffer
     public func consumeAll(on eventLoop: EventLoop, _ process: @escaping (ByteBuffer) -> EventLoopFuture<Void>) -> EventLoopFuture<Void> {
-        self.state.onLoop { state, eventLoop in
+        self.state.runOnLoop { state, eventLoop in
             state.consumeAll(on: eventLoop, process)
         }.hop(to: eventLoop)
     }
@@ -397,7 +397,7 @@ public final class HBByteBufferStreamer: HBStreamerProtocol, Sendable {
     /// - Parameters:
     ///   - eventLoop: EventLoop to run on
     func drop() -> EventLoopFuture<Void> {
-        self.state.onLoop { state, eventLoop in
+        self.state.runOnLoop { state, eventLoop in
             state.drop(eventLoop: eventLoop)
         }
     }
@@ -406,7 +406,7 @@ public final class HBByteBufferStreamer: HBStreamerProtocol, Sendable {
     /// - Parameter maxSize: Maximum size for the resultant ByteBuffer
     /// - Returns: EventLoopFuture that will be fulfilled when all buffers are consumed
     func collate(maxSize: Int) -> EventLoopFuture<ByteBuffer?> {
-        self.state.onLoop { state, eventLoop in
+        self.state.runOnLoop { state, eventLoop in
             state.collate(maxSize: maxSize, eventLoop: eventLoop)
         }
     }
@@ -454,7 +454,7 @@ final class HBStaticStreamer: HBStreamerProtocol {
 extension HBStaticStreamer: @unchecked Sendable {}
 
 extension NIOLoopBoundBox {
-    @discardableResult func onLoop<NewValue>(_ callback: @escaping (Value, EventLoop) -> EventLoopFuture<NewValue>) -> EventLoopFuture<NewValue> {
+    @discardableResult func runOnLoop<NewValue>(_ callback: @escaping (Value, EventLoop) -> EventLoopFuture<NewValue>) -> EventLoopFuture<NewValue> {
         if self._eventLoop.inEventLoop {
             return callback(self.value, self._eventLoop)
         } else {
@@ -464,7 +464,7 @@ extension NIOLoopBoundBox {
         }
     }
 
-    @discardableResult func onLoop<NewValue>(_ callback: @escaping (Value, EventLoop) throws -> NewValue) -> EventLoopFuture<NewValue> {
+    @discardableResult func runOnLoop<NewValue>(_ callback: @escaping (Value, EventLoop) throws -> NewValue) -> EventLoopFuture<NewValue> {
         if self._eventLoop.inEventLoop {
             return _eventLoop.makeCompletedFuture { try callback(self.value, self._eventLoop) }
         } else {

--- a/Sources/HummingbirdCore/Request/ByteBufferStreamer.swift
+++ b/Sources/HummingbirdCore/Request/ByteBufferStreamer.swift
@@ -40,13 +40,13 @@ public protocol HBStreamerProtocol: HBSendable {
 /// Request body streamer. `HBHTTPDecodeHandler` feeds this with ByteBuffers while the Router consumes them
 ///
 /// Can set as @unchecked Sendable as interface functions are only allowed to run on same EventLoop
-public final class HBByteBufferStreamer: HBStreamerProtocol {
+public final class HBByteBufferStreamer: HBStreamerProtocol, Sendable {
     public enum StreamerError: Swift.Error {
         case bodyDropped
     }
 
     /// Values we can feed the streamer with
-    public enum FeedInput {
+    public enum FeedInput: Sendable {
         case byteBuffer(ByteBuffer)
         case error(Error)
         case end
@@ -63,118 +63,287 @@ public final class HBByteBufferStreamer: HBStreamerProtocol {
         }
     }
 
-    /// Queue of streamer inputs
-    var queue: CircularBuffer<FeedInput>
-    /// Queue of promises waiting for streamer inputs.
-    var waitingQueue: CircularBuffer<EventLoopPromise<FeedInput>>
-    /// back pressure promise
-    var backPressurePromise: EventLoopPromise<Void>?
-    /// EventLoop everything is running on
-    let eventLoop: EventLoop
-    /// called every time a ByteBuffer is consumed
-    var onConsume: ((HBByteBufferStreamer) -> Void)?
-    /// maximum allowed size to upload
-    let maxSize: Int
-    /// maximum size currently being streamed before back pressure is applied
-    let maxStreamingBufferSize: Int
-    /// current size in memory
-    var currentSize: Int
-    /// bytes fed to streamer so far
-    var sizeFed: Int
-    /// is request streamer finished
-    var isFinishedFeeding: Bool
-    /// if finished the last result sent
-    var finishedResult: FeedInput?
+    class InternalState {
+        init(
+            queue: CircularBuffer<FeedInput>,
+            waitingQueue: CircularBuffer<EventLoopPromise<FeedInput>>,
+            backPressurePromise: EventLoopPromise<Void>? = nil,
+            onConsume: ((InternalState) -> Void)? = nil,
+            currentSize: Int,
+            sizeFed: Int,
+            isFinishedFeeding: Bool,
+            finishedResult: FeedInput? = nil,
+            maxSize: Int,
+            maxStreamingBufferSize: Int
+        ) {
+            self.queue = queue
+            self.waitingQueue = waitingQueue
+            self.backPressurePromise = backPressurePromise
+            self.onConsume = onConsume
+            self.currentSize = currentSize
+            self.sizeFed = sizeFed
+            self.isFinishedFeeding = isFinishedFeeding
+            self.finishedResult = finishedResult
+            self.maxSize = maxSize
+            self.maxStreamingBufferSize = maxStreamingBufferSize
+        }
+
+        /// Queue of streamer inputs
+        var queue: CircularBuffer<FeedInput>
+        /// Queue of promises waiting for streamer inputs.
+        var waitingQueue: CircularBuffer<EventLoopPromise<FeedInput>>
+        /// back pressure promise
+        var backPressurePromise: EventLoopPromise<Void>?
+        /// called every time a ByteBuffer is consumed
+        var onConsume: ((InternalState) -> Void)?
+        /// current size in memory
+        var currentSize: Int
+        /// bytes fed to streamer so far
+        var sizeFed: Int
+        /// is request streamer finished
+        var isFinishedFeeding: Bool
+        /// if finished the last result sent
+        var finishedResult: FeedInput?
+        /// maximum allowed size to upload
+        let maxSize: Int
+        /// maximum size currently being streamed before back pressure is applied
+        let maxStreamingBufferSize: Int
+
+        /// Feed a ByteBuffer to the request
+        /// - Parameter result: Bytebuffer or end tag
+        func feed(buffer: ByteBuffer, eventLoop: EventLoop) -> EventLoopFuture<Void> {
+            if let backPressurePromise = backPressurePromise {
+                return backPressurePromise.futureResult.always { _ in
+                    self.feed(.byteBuffer(buffer), eventLoop: eventLoop)
+                }
+            } else {
+                self.feed(.byteBuffer(buffer), eventLoop: eventLoop)
+                return eventLoop.makeSucceededVoidFuture()
+            }
+        }
+
+        /// Feed a ByteBuffer to the stream
+        /// - Parameter result: Bytebuffer or end tag
+        func feed(_ result: FeedInput, eventLoop: EventLoop) {
+            // don't add more results to queue if we are finished
+            guard self.isFinishedFeeding == false else { return }
+
+            switch result {
+            case .byteBuffer(let byteBuffer):
+                self.sizeFed += byteBuffer.readableBytes
+                self.currentSize += byteBuffer.readableBytes
+                if self.currentSize > self.maxStreamingBufferSize {
+                    self.backPressurePromise = eventLoop.makePromise()
+                }
+                if self.sizeFed > self.maxSize {
+                    self.feed(.error(HBHTTPError(.payloadTooLarge)), eventLoop: eventLoop)
+                } else {
+                    // if there is a promise of the waiting queue then succeed that.
+                    // otherwise add feed result to queue
+                    if let promise = self.waitingQueue.popFirst() {
+                        promise.succeed(result)
+                    } else {
+                        self.queue.append(result)
+                    }
+                }
+            case .error, .end:
+                self.isFinishedFeeding = true
+                // if waiting queue has any promises then complete all of those
+                // otherwise add feed result to queue
+                if self.waitingQueue.count > 0 {
+                    for promise in self.waitingQueue {
+                        promise.succeed(result)
+                    }
+                } else {
+                    self.queue.append(result)
+                }
+            }
+        }
+
+        /// Consume what has been fed to the request
+        /// - Returns: Returns an EventLoopFuture that will be fulfilled with array of ByteBuffers that has so far been fed to the request body
+        ///     and whether we have consumed an end tag
+        func consume(eventLoop: EventLoop) -> EventLoopFuture<HBStreamerOutput> {
+            if let finishedResult = self.finishedResult {
+                return eventLoop.makeCompletedFuture(finishedResult.streamerOutputResult)
+            }
+            // function for consuming feed input
+            func _consume(input: FeedInput) -> Result<HBStreamerOutput, Error> {
+                switch input {
+                case .byteBuffer(let buffer):
+                    self.currentSize -= buffer.readableBytes
+                    if self.currentSize < self.maxStreamingBufferSize {
+                        self.backPressurePromise?.succeed(())
+                    }
+                case .end:
+                    assert(self.currentSize == 0)
+                    self.finishedResult = input
+                default:
+                    self.finishedResult = input
+                }
+                self.onConsume?(self)
+                return input.streamerOutputResult
+            }
+
+            // if there is a result on the queue consume that otherwise create
+            // a promise and add it to the waiting queue and once that promise
+            // is complete consume the result
+            if let result = self.queue.popFirst() {
+                return eventLoop.makeCompletedFuture(_consume(input: result))
+            } else {
+                let promise = eventLoop.makePromise(of: FeedInput.self)
+                self.waitingQueue.append(promise)
+                return promise.futureResult.flatMapResult(_consume)
+            }
+        }
+
+        /// Consume the request body, calling `process` on each buffer until you receive an end tag
+        /// - Returns: EventLoopFuture that will be fulfilled when all ByteBuffers have been consumed
+        /// - Parameters:
+        ///   - eventLoop: EventLoop to run on
+        ///   - process: Closure to call to process ByteBuffer
+        public func consumeAll(on eventLoop: EventLoop, _ process: @escaping (ByteBuffer) -> EventLoopFuture<Void>) -> EventLoopFuture<Void> {
+            let promise = eventLoop.makePromise(of: Void.self)
+            func _consumeAll(_ count: Int) {
+                self.consume(eventLoop: eventLoop).whenComplete { result in
+                    switch result {
+                    case .success(.byteBuffer(let buffer)):
+                        process(buffer).whenComplete { result in
+                            switch result {
+                            case .failure(let error):
+                                promise.fail(error)
+                            case .success:
+                                // after 16 iterations, run via execute to avoid any possible
+                                // stack overflows
+                                if count > 16 {
+                                    eventLoop.execute {
+                                        _consumeAll(0)
+                                    }
+                                } else {
+                                    _consumeAll(count + 1)
+                                }
+                            }
+                        }
+
+                    case .success(.end):
+                        promise.succeed(())
+
+                    case .failure(let error):
+                        promise.fail(error)
+                    }
+                }
+            }
+            _consumeAll(0)
+            return promise.futureResult
+        }
+
+        /// Consume the request body, but ignore contents
+        /// - Returns: EventLoopFuture that will be fulfilled when all ByteBuffers have been consumed
+        /// - Parameters:
+        ///   - eventLoop: EventLoop to run on
+        func drop(eventLoop: EventLoop) -> EventLoopFuture<Void> {
+            self.isFinishedFeeding = true
+
+            let promise = eventLoop.makePromise(of: Void.self)
+            func _dropAll() {
+                self.consume(eventLoop: eventLoop).map { output in
+                    switch output {
+                    case .byteBuffer:
+                        _dropAll()
+
+                    case .end:
+                        promise.succeed(())
+                    }
+                }
+                .cascadeFailure(to: promise)
+            }
+            if self.waitingQueue.last != nil {
+                _dropAll()
+            } else {
+                promise.succeed(())
+            }
+            return promise.futureResult
+        }
+
+        /// Collate the request body into one ByteBuffer
+        /// - Parameter maxSize: Maximum size for the resultant ByteBuffer
+        /// - Returns: EventLoopFuture that will be fulfilled when all buffers are consumed
+        func collate(maxSize: Int, eventLoop: EventLoop) -> EventLoopFuture<ByteBuffer?> {
+            let promise = eventLoop.makePromise(of: ByteBuffer?.self)
+            var completeBuffer: ByteBuffer?
+            func _consumeAll(size: Int) {
+                self.consume(eventLoop: eventLoop).whenComplete { result in
+                    switch result {
+                    case .success(.byteBuffer(var buffer)):
+                        let size = size + buffer.readableBytes
+                        if size > maxSize {
+                            promise.fail(HBHTTPError(.payloadTooLarge))
+                        }
+                        if completeBuffer != nil {
+                            completeBuffer!.writeBuffer(&buffer)
+                        } else {
+                            completeBuffer = buffer
+                        }
+                        _consumeAll(size: size)
+
+                    case .success(.end):
+                        promise.succeed(completeBuffer)
+
+                    case .failure(let error):
+                        promise.fail(error)
+                    }
+                }
+            }
+            _consumeAll(size: 0)
+            return promise.futureResult
+        }
+    }
+
+    /// state wrapped in a NIOLoopBoubdBox to ensure state is only ever accessed from eventloop
+    let state: NIOLoopBoundBox<InternalState>
 
     public init(eventLoop: EventLoop, maxSize: Int, maxStreamingBufferSize: Int? = nil) {
-        self.queue = .init()
-        self.waitingQueue = .init()
-        self.backPressurePromise = nil
-        self.eventLoop = eventLoop
-        self.sizeFed = 0
-        self.currentSize = 0
-        self.maxSize = maxSize
-        self.maxStreamingBufferSize = maxStreamingBufferSize ?? maxSize
-        self.onConsume = nil
-        self.isFinishedFeeding = false
-        self.finishedResult = nil
+        self.state = .init(
+            .init(
+                queue: .init(),
+                waitingQueue: .init(),
+                backPressurePromise: nil,
+                onConsume: nil,
+                currentSize: 0,
+                sizeFed: 0,
+                isFinishedFeeding: false,
+                finishedResult: nil,
+                maxSize: maxSize,
+                maxStreamingBufferSize: maxStreamingBufferSize ?? maxSize
+            ),
+            eventLoop: eventLoop
+        )
     }
 
     /// Feed a ByteBuffer to the request, while applying back pressure
     /// - Parameter result: Bytebuffer or end tag
     public func feed(buffer: ByteBuffer) -> EventLoopFuture<Void> {
-        if self.eventLoop.inEventLoop {
-            return self._feed(buffer: buffer)
-        } else {
-            return self.eventLoop.flatSubmit {
-                self._feed(buffer: buffer)
-            }
-        }
-    }
-
-    /// Feed a ByteBuffer to the request
-    /// - Parameter result: Bytebuffer or end tag
-    private func _feed(buffer: ByteBuffer) -> EventLoopFuture<Void> {
-        self.eventLoop.assertInEventLoop()
-        if let backPressurePromise = backPressurePromise {
-            return backPressurePromise.futureResult.always { _ in
-                self._feed(.byteBuffer(buffer))
-            }
-        } else {
-            self._feed(.byteBuffer(buffer))
-            return self.eventLoop.makeSucceededVoidFuture()
+        self.state.onLoop { state, eventLoop in
+            state.feed(buffer: buffer, eventLoop: eventLoop)
         }
     }
 
     /// Feed a ByteBuffer to the request
     /// - Parameter result: Bytebuffer or end tag
     public func feed(_ result: FeedInput) {
-        if self.eventLoop.inEventLoop {
-            self._feed(result)
-        } else {
-            self.eventLoop.execute {
-                self._feed(result)
-            }
+        self.state.onLoop { state, eventLoop in
+            state.feed(result, eventLoop: eventLoop)
         }
     }
 
-    /// Feed a ByteBuffer to the stream
-    /// - Parameter result: Bytebuffer or end tag
-    private func _feed(_ result: FeedInput) {
-        // don't add more results to queue if we are finished
-        guard self.isFinishedFeeding == false else { return }
-
-        self.eventLoop.assertInEventLoop()
-
-        switch result {
-        case .byteBuffer(let byteBuffer):
-            self.sizeFed += byteBuffer.readableBytes
-            self.currentSize += byteBuffer.readableBytes
-            if self.currentSize > self.maxStreamingBufferSize {
-                self.backPressurePromise = self.eventLoop.makePromise()
-            }
-            if self.sizeFed > self.maxSize {
-                self._feed(.error(HBHTTPError(.payloadTooLarge)))
-            } else {
-                // if there is a promise of the waiting queue then succeed that.
-                // otherwise add feed result to queue
-                if let promise = self.waitingQueue.popFirst() {
-                    promise.succeed(result)
-                } else {
-                    self.queue.append(result)
-                }
-            }
-        case .error, .end:
-            self.isFinishedFeeding = true
-            // if waiting queue has any promises then complete all of those
-            // otherwise add feed result to queue
-            if self.waitingQueue.count > 0 {
-                for promise in self.waitingQueue {
-                    promise.succeed(result)
-                }
-            } else {
-                self.queue.append(result)
-            }
+    /// Consume what has been fed to the request
+    ///
+    /// - Parameter eventLoop: EventLoop to return future on
+    /// - Returns: Returns an EventLoopFuture that will be fulfilled with array of ByteBuffers that has so far been fed to th request body
+    ///     and whether we have consumed everything
+    public func consume() -> EventLoopFuture<HBStreamerOutput> {
+        self.state.onLoop { state, eventLoop in
+            state.consume(eventLoop: eventLoop)
         }
     }
 
@@ -184,12 +353,19 @@ public final class HBByteBufferStreamer: HBStreamerProtocol {
     /// - Returns: Returns an EventLoopFuture that will be fulfilled with array of ByteBuffers that has so far been fed to th request body
     ///     and whether we have consumed everything
     public func consume(on eventLoop: EventLoop) -> EventLoopFuture<HBStreamerOutput> {
-        if self.eventLoop.inEventLoop {
-            return self.consume().hop(to: eventLoop)
-        } else {
-            return self.eventLoop.flatSubmit {
-                self.consume()
-            }.hop(to: eventLoop)
+        self.state.onLoop { state, eventLoop in
+            state.consume(eventLoop: eventLoop)
+        }.hop(to: eventLoop)
+    }
+
+    /// Consume the request body, calling `process` on each buffer until you receive an end tag
+    /// - Returns: EventLoopFuture that will be fulfilled when all ByteBuffers have been consumed
+    /// - Parameters:
+    ///   - eventLoop: EventLoop to run on
+    ///   - process: Closure to call to process ByteBuffer
+    public func consumeAll(_ process: @escaping (ByteBuffer) -> EventLoopFuture<Void>) -> EventLoopFuture<Void> {
+        self.state.onLoop { state, eventLoop in
+            state.consumeAll(on: eventLoop, process)
         }
     }
 
@@ -199,40 +375,9 @@ public final class HBByteBufferStreamer: HBStreamerProtocol {
     ///   - eventLoop: EventLoop to run on
     ///   - process: Closure to call to process ByteBuffer
     public func consumeAll(on eventLoop: EventLoop, _ process: @escaping (ByteBuffer) -> EventLoopFuture<Void>) -> EventLoopFuture<Void> {
-        let promise = self.eventLoop.makePromise(of: Void.self)
-        func _consumeAll(_ count: Int) {
-            self.consume().whenComplete { result in
-                switch result {
-                case .success(.byteBuffer(let buffer)):
-                    process(buffer).whenComplete { result in
-                        switch result {
-                        case .failure(let error):
-                            promise.fail(error)
-                        case .success:
-                            // after 16 iterations, run via execute to avoid any possible
-                            // stack overflows
-                            if count > 16 {
-                                self.eventLoop.execute {
-                                    _consumeAll(0)
-                                }
-                            } else {
-                                _consumeAll(count + 1)
-                            }
-                        }
-                    }
-
-                case .success(.end):
-                    promise.succeed(())
-
-                case .failure(let error):
-                    promise.fail(error)
-                }
-            }
-        }
-        self.eventLoop.execute {
-            _consumeAll(0)
-        }
-        return promise.futureResult
+        self.state.onLoop { state, eventLoop in
+            state.consumeAll(on: eventLoop, process)
+        }.hop(to: eventLoop)
     }
 
     /// Consume the request body, but ignore contents
@@ -240,64 +385,8 @@ public final class HBByteBufferStreamer: HBStreamerProtocol {
     /// - Parameters:
     ///   - eventLoop: EventLoop to run on
     func drop() -> EventLoopFuture<Void> {
-        self.eventLoop.assertInEventLoop()
-        self.isFinishedFeeding = true
-
-        let promise = self.eventLoop.makePromise(of: Void.self)
-        func _dropAll() {
-            self.consume(on: self.eventLoop).map { output in
-                switch output {
-                case .byteBuffer:
-                    _dropAll()
-
-                case .end:
-                    promise.succeed(())
-                }
-            }
-            .cascadeFailure(to: promise)
-        }
-        if self.waitingQueue.last != nil {
-            _dropAll()
-        } else {
-            promise.succeed(())
-        }
-        return promise.futureResult
-    }
-
-    /// Consume what has been fed to the request
-    /// - Returns: Returns an EventLoopFuture that will be fulfilled with array of ByteBuffers that has so far been fed to the request body
-    ///     and whether we have consumed an end tag
-    func consume() -> EventLoopFuture<HBStreamerOutput> {
-        if let finishedResult = self.finishedResult {
-            return self.eventLoop.makeCompletedFuture(finishedResult.streamerOutputResult)
-        }
-        // function for consuming feed input
-        func _consume(input: FeedInput) -> Result<HBStreamerOutput, Error> {
-            switch input {
-            case .byteBuffer(let buffer):
-                self.currentSize -= buffer.readableBytes
-                if self.currentSize < self.maxStreamingBufferSize {
-                    self.backPressurePromise?.succeed(())
-                }
-            case .end:
-                assert(self.currentSize == 0)
-                self.finishedResult = input
-            default:
-                self.finishedResult = input
-            }
-            self.onConsume?(self)
-            return input.streamerOutputResult
-        }
-        self.eventLoop.assertInEventLoop()
-        // if there is a result on the queue consume that otherwise create
-        // a promise and add it to the waiting queue and once that promise
-        // is complete consume the result
-        if let result = self.queue.popFirst() {
-            return self.eventLoop.makeCompletedFuture(_consume(input: result))
-        } else {
-            let promise = self.eventLoop.makePromise(of: FeedInput.self)
-            self.waitingQueue.append(promise)
-            return promise.futureResult.flatMapResult(_consume)
+        self.state.onLoop { state, eventLoop in
+            state.drop(eventLoop: eventLoop)
         }
     }
 
@@ -305,33 +394,9 @@ public final class HBByteBufferStreamer: HBStreamerProtocol {
     /// - Parameter maxSize: Maximum size for the resultant ByteBuffer
     /// - Returns: EventLoopFuture that will be fulfilled when all buffers are consumed
     func collate(maxSize: Int) -> EventLoopFuture<ByteBuffer?> {
-        let promise = self.eventLoop.makePromise(of: ByteBuffer?.self)
-        var completeBuffer: ByteBuffer?
-        func _consumeAll(size: Int) {
-            self.consume().whenComplete { result in
-                switch result {
-                case .success(.byteBuffer(var buffer)):
-                    let size = size + buffer.readableBytes
-                    if size > maxSize {
-                        promise.fail(HBHTTPError(.payloadTooLarge))
-                    }
-                    if completeBuffer != nil {
-                        completeBuffer!.writeBuffer(&buffer)
-                    } else {
-                        completeBuffer = buffer
-                    }
-                    _consumeAll(size: size)
-
-                case .success(.end):
-                    promise.succeed(completeBuffer)
-
-                case .failure(let error):
-                    promise.fail(error)
-                }
-            }
+        self.state.onLoop { state, eventLoop in
+            state.collate(maxSize: maxSize, eventLoop: eventLoop)
         }
-        _consumeAll(size: 0)
-        return promise.futureResult
     }
 }
 
@@ -368,5 +433,26 @@ final class HBStaticStreamer: HBStreamerProtocol {
     }
 }
 
-extension HBByteBufferStreamer: @unchecked Sendable {}
 extension HBStaticStreamer: @unchecked Sendable {}
+
+extension NIOLoopBoundBox {
+    @discardableResult func onLoop<NewValue>(_ callback: @escaping (Value, EventLoop) -> EventLoopFuture<NewValue>) -> EventLoopFuture<NewValue> {
+        if self._eventLoop.inEventLoop {
+            return callback(self.value, self._eventLoop)
+        } else {
+            return self._eventLoop.flatSubmit {
+                callback(self.value, self._eventLoop)
+            }
+        }
+    }
+
+    @discardableResult func onLoop<NewValue>(_ callback: @escaping (Value, EventLoop) throws -> NewValue) -> EventLoopFuture<NewValue> {
+        if self._eventLoop.inEventLoop {
+            return _eventLoop.makeCompletedFuture { try callback(self.value, self._eventLoop) }
+        } else {
+            return self._eventLoop.submit {
+                try callback(self.value, self._eventLoop)
+            }
+        }
+    }
+}

--- a/Sources/HummingbirdCore/Request/ByteBufferStreamer.swift
+++ b/Sources/HummingbirdCore/Request/ByteBufferStreamer.swift
@@ -202,7 +202,7 @@ public final class HBByteBufferStreamer: HBStreamerProtocol, Sendable {
         /// - Parameters:
         ///   - eventLoop: EventLoop to run on
         ///   - process: Closure to call to process ByteBuffer
-        public func consumeAll(on eventLoop: EventLoop, _ process: @escaping (ByteBuffer) -> EventLoopFuture<Void>) -> EventLoopFuture<Void> {
+        func consumeAll(on eventLoop: EventLoop, _ process: @escaping (ByteBuffer) -> EventLoopFuture<Void>) -> EventLoopFuture<Void> {
             let promise = eventLoop.makePromise(of: Void.self)
             func _consumeAll(_ count: Int) {
                 self.consume(eventLoop: eventLoop).whenComplete { result in

--- a/Sources/HummingbirdCore/Request/ByteBufferStreamer.swift
+++ b/Sources/HummingbirdCore/Request/ByteBufferStreamer.swift
@@ -364,9 +364,10 @@ public final class HBByteBufferStreamer: HBStreamerProtocol, Sendable {
     /// - Parameter eventLoop: EventLoop to return future on
     /// - Returns: Returns an EventLoopFuture that will be fulfilled with array of ByteBuffers that has so far been fed to th request body
     ///     and whether we have consumed everything
+    @available(*, deprecated, message: "Use consume(). If you need to jump to another EventLoop use hop(to:).")
     public func consume(on eventLoop: EventLoop) -> EventLoopFuture<HBStreamerOutput> {
-        self.state.runOnLoop { state, eventLoop in
-            state.consume(eventLoop: eventLoop)
+        self.state.runOnLoop { state, stateEventLoop in
+            state.consume(eventLoop: stateEventLoop)
         }.hop(to: eventLoop)
     }
 
@@ -386,9 +387,10 @@ public final class HBByteBufferStreamer: HBStreamerProtocol, Sendable {
     /// - Parameters:
     ///   - eventLoop: EventLoop to run on
     ///   - process: Closure to call to process ByteBuffer
+    @available(*, deprecated, message: "Use consumeAll(_:). If you need to jump to another EventLoop use hop(to:).")
     public func consumeAll(on eventLoop: EventLoop, _ process: @escaping (ByteBuffer) -> EventLoopFuture<Void>) -> EventLoopFuture<Void> {
-        self.state.runOnLoop { state, eventLoop in
-            state.consumeAll(on: eventLoop, process)
+        self.state.runOnLoop { state, stateEventLoop in
+            state.consumeAll(on: stateEventLoop, process)
         }.hop(to: eventLoop)
     }
 

--- a/Sources/HummingbirdCore/Request/RequestBody.swift
+++ b/Sources/HummingbirdCore/Request/RequestBody.swift
@@ -108,11 +108,7 @@ extension HBRequestBody {
         case .byteBuffer(let buffer):
             return buffer
         case .stream(let streamer):
-            if !streamer.eventLoop.inEventLoop {
-                return try await streamer.eventLoop.flatSubmit { streamer.collate(maxSize: maxSize) }.get()
-            } else {
-                return try await streamer.collate(maxSize: maxSize).get()
-            }
+            return try await streamer.collate(maxSize: maxSize).get()
         }
     }
 }

--- a/Sources/HummingbirdCore/Server/HTTPServerHandler.swift
+++ b/Sources/HummingbirdCore/Server/HTTPServerHandler.swift
@@ -281,8 +281,8 @@ final class HBHTTPServerHandler: ChannelDuplexHandler, RemovableChannelHandler {
 
     func read(context: ChannelHandlerContext) {
         if case .streamingBody(let streamer) = self.state {
-            guard streamer.currentSize < self.configuration.maxStreamingBufferSize else {
-                streamer.onConsume = { streamer in
+            guard streamer.state.value.currentSize < self.configuration.maxStreamingBufferSize else {
+                streamer.state.value.onConsume = { streamer in
                     if streamer.currentSize < self.configuration.maxStreamingBufferSize {
                         context.read()
                     }

--- a/Sources/HummingbirdCore/Server/HTTPServerHandler.swift
+++ b/Sources/HummingbirdCore/Server/HTTPServerHandler.swift
@@ -72,7 +72,11 @@ final class HBHTTPServerHandler: ChannelDuplexHandler, RemovableChannelHandler {
             self.state = .body(head, part)
 
         case (.body(let part), .body(let head, let buffer)):
-            let streamer = HBByteBufferStreamer(eventLoop: context.eventLoop, maxSize: self.configuration.maxUploadSize)
+            let streamer = HBByteBufferStreamer(
+                eventLoop: context.eventLoop,
+                maxSize: self.configuration.maxUploadSize,
+                maxStreamingBufferSize: self.configuration.maxStreamingBufferSize
+            )
             let request = HBHTTPRequest(head: head, body: .stream(streamer))
             streamer.feed(.byteBuffer(buffer))
             streamer.feed(.byteBuffer(part))
@@ -281,12 +285,10 @@ final class HBHTTPServerHandler: ChannelDuplexHandler, RemovableChannelHandler {
 
     func read(context: ChannelHandlerContext) {
         if case .streamingBody(let streamer) = self.state {
-            guard streamer.state.value.currentSize < self.configuration.maxStreamingBufferSize else {
-                streamer.state.value.onConsume = { streamer in
-                    if streamer.currentSize < self.configuration.maxStreamingBufferSize {
-                        context.read()
-                    }
-                }
+            // test streamer didn't need to apply backpressure
+            guard !streamer.isBackpressureRequired({
+                context.read()
+            }) else {
                 return
             }
         }

--- a/Tests/HummingbirdCoreTests/StreamerTests.swift
+++ b/Tests/HummingbirdCoreTests/StreamerTests.swift
@@ -59,7 +59,7 @@ class ByteBufferStreamerTests: XCTestCase {
         func _feed() {
             let blockSize = min(buffer.readableBytes, 32 * 1024)
             streamer.feed(buffer: buffer.readSlice(length: blockSize)!).whenComplete { _ in
-                XCTAssertLessThanOrEqual(streamer.currentSize, streamer.maxStreamingBufferSize + blockSize)
+                XCTAssertLessThanOrEqual(streamer.state.value.currentSize, streamer.state.value.maxStreamingBufferSize + blockSize)
                 if buffer.readableBytes > 0 {
                     _feed()
                 } else {
@@ -75,7 +75,7 @@ class ByteBufferStreamerTests: XCTestCase {
         func _feed() {
             let blockSize = min(buffer.readableBytes, 32 * 1024)
             streamer.feed(buffer: buffer.readSlice(length: blockSize)!).whenComplete { _ in
-                XCTAssertLessThanOrEqual(streamer.currentSize, streamer.maxStreamingBufferSize + blockSize)
+                XCTAssertLessThanOrEqual(streamer.state.value.currentSize, streamer.state.value.maxStreamingBufferSize + blockSize)
                 if buffer.readableBytes > 0 {
                     eventLoop.scheduleTask(in: .microseconds(Int64.random(in: 0..<100_000))) {
                         _feed()
@@ -110,72 +110,88 @@ class ByteBufferStreamerTests: XCTestCase {
     func testFeedConsume() throws {
         let buffer = self.randomBuffer(size: 128_000)
         let eventLoop = self.elg.next()
-        let streamer = HBByteBufferStreamer(eventLoop: eventLoop, maxSize: 1024 * 1024)
 
-        self.feedStreamer(streamer, buffer: buffer, eventLoop: eventLoop)
-        let consumeBuffer = try consumeStreamer(streamer, eventLoop: eventLoop).wait()
+        try eventLoop.flatSubmit {
+            let streamer = HBByteBufferStreamer(eventLoop: eventLoop, maxSize: 1024 * 1024)
 
-        XCTAssertEqual(buffer, consumeBuffer)
+            self.feedStreamer(streamer, buffer: buffer, eventLoop: eventLoop)
+            return self.consumeStreamer(streamer, eventLoop: eventLoop).map { consumeBuffer in
+                XCTAssertEqual(buffer, consumeBuffer)
+            }
+        }.wait()
     }
 
     /// Test can feed from not the EventLoop and then consume
     func testFeedOffEventLoop() throws {
         let buffer = self.randomBuffer(size: 128_000)
         let eventLoop = self.elg.next()
-        let streamer = HBByteBufferStreamer(eventLoop: eventLoop, maxSize: 1024 * 1024)
+        try eventLoop.flatSubmit {
+            let streamer = HBByteBufferStreamer(eventLoop: eventLoop, maxSize: 1024 * 1024)
 
-        self.feedStreamer(streamer, buffer: buffer)
-        let consumeBuffer = try consumeStreamer(streamer, eventLoop: eventLoop).wait()
-
-        XCTAssertEqual(buffer, consumeBuffer)
+            self.feedStreamer(streamer, buffer: buffer, eventLoop: self.elg.next())
+            return self.consumeStreamer(streamer, eventLoop: eventLoop).map { consumeBuffer in
+                XCTAssertEqual(buffer, consumeBuffer)
+            }
+        }.wait()
     }
 
     /// Test can feed and then consume with back pressure applied
     func testFeedWithBackPressure() throws {
         let buffer = self.randomBuffer(size: 128_000)
         let eventLoop = self.elg.next()
-        let streamer = HBByteBufferStreamer(eventLoop: eventLoop, maxSize: 1024 * 1024, maxStreamingBufferSize: 20 * 1024)
 
-        self.feedStreamerWithBackPressure(streamer, buffer: buffer)
-        let consumeBuffer = try consumeStreamer(streamer, eventLoop: eventLoop).wait()
+        try eventLoop.flatSubmit {
+            let streamer = HBByteBufferStreamer(eventLoop: eventLoop, maxSize: 1024 * 1024, maxStreamingBufferSize: 20 * 1024)
 
-        XCTAssertEqual(buffer, consumeBuffer)
+            self.feedStreamerWithBackPressure(streamer, buffer: buffer)
+            return self.consumeStreamer(streamer, eventLoop: eventLoop).map { consumeBuffer in
+                XCTAssertEqual(buffer, consumeBuffer)
+            }
+        }.wait()
     }
 
     /// Test can feed and then consume with delays and back pressure applied
     func testFeedWithBackPressureConsumeDelays() throws {
         let buffer = self.randomBuffer(size: 600_000)
         let eventLoop = self.elg.next()
-        let streamer = HBByteBufferStreamer(eventLoop: eventLoop, maxSize: 1024 * 1024, maxStreamingBufferSize: 64 * 1024)
 
-        self.feedStreamerWithBackPressure(streamer, buffer: buffer)
-        let consumeBuffer = try consumeStreamerWithDelays(streamer, eventLoop: eventLoop).wait()
+        try eventLoop.flatSubmit {
+            let streamer = HBByteBufferStreamer(eventLoop: eventLoop, maxSize: 1024 * 1024, maxStreamingBufferSize: 64 * 1024)
 
-        XCTAssertEqual(buffer, consumeBuffer)
+            self.feedStreamerWithBackPressure(streamer, buffer: buffer)
+            return self.consumeStreamerWithDelays(streamer, eventLoop: eventLoop).map { consumeBuffer in
+                XCTAssertEqual(buffer, consumeBuffer)
+            }
+        }.wait()
     }
 
     /// Test can feed and then consume
     func testFeedWithBackPressureAndDelays() throws {
         let buffer = self.randomBuffer(size: 400_000)
         let eventLoop = self.elg.next()
-        let streamer = HBByteBufferStreamer(eventLoop: eventLoop, maxSize: 1024 * 1024, maxStreamingBufferSize: 64 * 1024)
 
-        self.feedStreamerWithDelays(streamer, buffer: buffer, eventLoop: eventLoop)
-        let consumeBuffer = try consumeStreamer(streamer, eventLoop: eventLoop).wait()
+        try eventLoop.flatSubmit {
+            let streamer = HBByteBufferStreamer(eventLoop: eventLoop, maxSize: 1024 * 1024, maxStreamingBufferSize: 64 * 1024)
 
-        XCTAssertEqual(buffer, consumeBuffer)
+            self.feedStreamerWithDelays(streamer, buffer: buffer, eventLoop: eventLoop)
+            return self.consumeStreamer(streamer, eventLoop: eventLoop).map { consumeBuffer in
+                XCTAssertEqual(buffer, consumeBuffer)
+            }
+        }.wait()
     }
 
     /// Test can feed and then consume
     func testFeedAndConsumeWithDelays() throws {
         let buffer = self.randomBuffer(size: 550_000)
         let eventLoop = self.elg.next()
-        let streamer = HBByteBufferStreamer(eventLoop: eventLoop, maxSize: 1024 * 1024, maxStreamingBufferSize: 64 * 1024)
+        try eventLoop.flatSubmit {
+            let streamer = HBByteBufferStreamer(eventLoop: eventLoop, maxSize: 1024 * 1024, maxStreamingBufferSize: 64 * 1024)
 
-        self.feedStreamerWithDelays(streamer, buffer: buffer, eventLoop: eventLoop)
-        let consumeBuffer = try consumeStreamerWithDelays(streamer, eventLoop: eventLoop).wait()
-
-        XCTAssertEqual(buffer, consumeBuffer)
+            self.feedStreamerWithDelays(streamer, buffer: buffer, eventLoop: eventLoop)
+            return self.consumeStreamerWithDelays(streamer, eventLoop: eventLoop).map { consumeBuffer in
+                XCTAssertEqual(buffer, consumeBuffer)
+            }
+        }.wait()
     }
 
     /// Test can run multiple consumes at same time
@@ -183,8 +199,8 @@ class ByteBufferStreamerTests: XCTestCase {
         let originalBuffer = self.randomBuffer(size: 20000)
         var buffer = originalBuffer
         let eventLoop = self.elg.next()
-        let streamer = HBByteBufferStreamer(eventLoop: eventLoop, maxSize: 1024 * 1024, maxStreamingBufferSize: 64 * 1024)
         let finalBuffer = try eventLoop.flatSubmit { () -> EventLoopFuture<ByteBuffer> in
+            let streamer = HBByteBufferStreamer(eventLoop: eventLoop, maxSize: 1024 * 1024, maxStreamingBufferSize: 64 * 1024)
             let consumeRequests: [EventLoopFuture<HBStreamerOutput>] = (0..<4).map { _ in streamer.consume() }
 
             while let slice = buffer.readSlice(length: 5000) {
@@ -210,8 +226,8 @@ class ByteBufferStreamerTests: XCTestCase {
         let originalBuffer = self.randomBuffer(size: 20000)
         var buffer = originalBuffer
         let eventLoop = self.elg.next()
-        let streamer = HBByteBufferStreamer(eventLoop: eventLoop, maxSize: 1024 * 1024, maxStreamingBufferSize: 64 * 1024)
         let finalBuffer = try eventLoop.flatSubmit { () -> EventLoopFuture<ByteBuffer> in
+            let streamer = HBByteBufferStreamer(eventLoop: eventLoop, maxSize: 1024 * 1024, maxStreamingBufferSize: 64 * 1024)
             var finalBuffer = ByteBufferAllocator().buffer(capacity: 20000)
             var consumeRequests: [EventLoopFuture<HBStreamerOutput>] = (0..<5).map { _ in streamer.consume() }
             while let slice = buffer.readSlice(length: 2000) {
@@ -236,29 +252,39 @@ class ByteBufferStreamerTests: XCTestCase {
     func testMaxSize() throws {
         let buffer = self.randomBuffer(size: 60000)
         let eventLoop = self.elg.next()
-        let streamer = HBByteBufferStreamer(eventLoop: eventLoop, maxSize: 32 * 1024)
-        self.feedStreamer(streamer, buffer: buffer)
-        XCTAssertThrowsError(try self.consumeStreamer(streamer, eventLoop: eventLoop).wait()) { error in
-            switch error {
-            case let error as HBHTTPError:
-                XCTAssertEqual(error.status, .payloadTooLarge)
-            default:
-                XCTFail("\(error)")
+        try eventLoop.flatSubmit {
+            let streamer = HBByteBufferStreamer(eventLoop: eventLoop, maxSize: 32 * 1024)
+            self.feedStreamer(streamer, buffer: buffer)
+            return self.consumeStreamer(streamer, eventLoop: eventLoop).map { _ in
+                XCTFail("Should not get here")
+            }.flatMapErrorThrowing { error in
+                switch error {
+                case let error as HBHTTPError:
+                    XCTAssertEqual(error.status, .payloadTooLarge)
+                default:
+                    XCTFail("\(error)")
+                }
             }
-        }
+        }.wait()
     }
 
     func testCallingConsumeAfterEnd() throws {
         let buffer = self.randomBuffer(size: 1)
         let eventLoop = self.elg.next()
-        let streamer = HBByteBufferStreamer(eventLoop: eventLoop, maxSize: 32 * 1024)
-        streamer.feed(.byteBuffer(buffer))
-        streamer.feed(.end)
-        _ = try streamer.consume(on: eventLoop).wait()
-        let end1 = try streamer.consume(on: eventLoop).wait()
-        let end2 = try streamer.consume(on: eventLoop).wait()
-        XCTAssertEqual(end1, .end)
-        XCTAssertEqual(end2, .end)
+        try eventLoop.flatSubmit {
+            let streamer = HBByteBufferStreamer(eventLoop: eventLoop, maxSize: 32 * 1024)
+            streamer.feed(.byteBuffer(buffer))
+            streamer.feed(.end)
+
+            return streamer.consume(on: eventLoop).flatMap { _ in
+                return streamer.consume(on: eventLoop)
+            }.flatMap { (end: HBStreamerOutput) in
+                XCTAssertEqual(end, .end)
+                return streamer.consume(on: eventLoop)
+            }.map { (end: HBStreamerOutput) in
+                XCTAssertEqual(end, .end)
+            }
+        }.wait()
     }
 
     /// test error is propagated
@@ -266,21 +292,25 @@ class ByteBufferStreamerTests: XCTestCase {
         struct MyError: Error {}
         var buffer = self.randomBuffer(size: 10000)
         let eventLoop = self.elg.next()
-        let streamer = HBByteBufferStreamer(eventLoop: eventLoop, maxSize: 32 * 1024)
+        try eventLoop.flatSubmit { () in
+            let streamer = HBByteBufferStreamer(eventLoop: eventLoop, maxSize: 32 * 1024)
 
-        while buffer.readableBytes > 0 {
-            let blockSize = min(buffer.readableBytes, 32 * 1024)
-            streamer.feed(.byteBuffer(buffer.readSlice(length: blockSize)!))
-        }
-        streamer.feed(.error(MyError()))
-
-        XCTAssertThrowsError(try self.consumeStreamer(streamer, eventLoop: eventLoop).wait()) { error in
-            switch error {
-            case is MyError:
-                break
-            default:
-                XCTFail("\(error)")
+            while buffer.readableBytes > 0 {
+                let blockSize = min(buffer.readableBytes, 32 * 1024)
+                streamer.feed(.byteBuffer(buffer.readSlice(length: blockSize)!))
             }
-        }
+            streamer.feed(.error(MyError()))
+
+            return self.consumeStreamer(streamer, eventLoop: eventLoop).map { _ in
+                XCTFail("Should not get here")
+            }.flatMapErrorThrowing { error in
+                switch error {
+                case is MyError:
+                    break
+                default:
+                    XCTFail("\(error)")
+                }
+            }
+        }.wait()
     }
 }

--- a/Tests/HummingbirdCoreTests/StreamerTests.swift
+++ b/Tests/HummingbirdCoreTests/StreamerTests.swift
@@ -111,7 +111,7 @@ class ByteBufferStreamerTests: XCTestCase {
         let buffer = self.randomBuffer(size: 128_000)
         let eventLoop = self.elg.next()
 
-        try eventLoop.flatSubmit {
+        try eventLoop.flatSubmit { () -> EventLoopFuture<Void> in
             let streamer = HBByteBufferStreamer(eventLoop: eventLoop, maxSize: 1024 * 1024)
 
             self.feedStreamer(streamer, buffer: buffer, eventLoop: eventLoop)
@@ -125,7 +125,7 @@ class ByteBufferStreamerTests: XCTestCase {
     func testFeedOffEventLoop() throws {
         let buffer = self.randomBuffer(size: 128_000)
         let eventLoop = self.elg.next()
-        try eventLoop.flatSubmit {
+        try eventLoop.flatSubmit { () -> EventLoopFuture<Void> in
             let streamer = HBByteBufferStreamer(eventLoop: eventLoop, maxSize: 1024 * 1024)
 
             self.feedStreamer(streamer, buffer: buffer, eventLoop: self.elg.next())
@@ -140,7 +140,7 @@ class ByteBufferStreamerTests: XCTestCase {
         let buffer = self.randomBuffer(size: 128_000)
         let eventLoop = self.elg.next()
 
-        try eventLoop.flatSubmit {
+        try eventLoop.flatSubmit { () -> EventLoopFuture<Void> in
             let streamer = HBByteBufferStreamer(eventLoop: eventLoop, maxSize: 1024 * 1024, maxStreamingBufferSize: 20 * 1024)
 
             self.feedStreamerWithBackPressure(streamer, buffer: buffer)
@@ -155,7 +155,7 @@ class ByteBufferStreamerTests: XCTestCase {
         let buffer = self.randomBuffer(size: 600_000)
         let eventLoop = self.elg.next()
 
-        try eventLoop.flatSubmit {
+        try eventLoop.flatSubmit { () -> EventLoopFuture<Void> in
             let streamer = HBByteBufferStreamer(eventLoop: eventLoop, maxSize: 1024 * 1024, maxStreamingBufferSize: 64 * 1024)
 
             self.feedStreamerWithBackPressure(streamer, buffer: buffer)
@@ -170,7 +170,7 @@ class ByteBufferStreamerTests: XCTestCase {
         let buffer = self.randomBuffer(size: 400_000)
         let eventLoop = self.elg.next()
 
-        try eventLoop.flatSubmit {
+        try eventLoop.flatSubmit { () -> EventLoopFuture<Void> in
             let streamer = HBByteBufferStreamer(eventLoop: eventLoop, maxSize: 1024 * 1024, maxStreamingBufferSize: 64 * 1024)
 
             self.feedStreamerWithDelays(streamer, buffer: buffer, eventLoop: eventLoop)
@@ -184,7 +184,7 @@ class ByteBufferStreamerTests: XCTestCase {
     func testFeedAndConsumeWithDelays() throws {
         let buffer = self.randomBuffer(size: 550_000)
         let eventLoop = self.elg.next()
-        try eventLoop.flatSubmit {
+        try eventLoop.flatSubmit { () -> EventLoopFuture<Void> in
             let streamer = HBByteBufferStreamer(eventLoop: eventLoop, maxSize: 1024 * 1024, maxStreamingBufferSize: 64 * 1024)
 
             self.feedStreamerWithDelays(streamer, buffer: buffer, eventLoop: eventLoop)
@@ -252,7 +252,7 @@ class ByteBufferStreamerTests: XCTestCase {
     func testMaxSize() throws {
         let buffer = self.randomBuffer(size: 60000)
         let eventLoop = self.elg.next()
-        try eventLoop.flatSubmit {
+        try eventLoop.flatSubmit { () -> EventLoopFuture<Void> in
             let streamer = HBByteBufferStreamer(eventLoop: eventLoop, maxSize: 32 * 1024)
             self.feedStreamer(streamer, buffer: buffer)
             return self.consumeStreamer(streamer, eventLoop: eventLoop).map { _ in
@@ -271,7 +271,7 @@ class ByteBufferStreamerTests: XCTestCase {
     func testCallingConsumeAfterEnd() throws {
         let buffer = self.randomBuffer(size: 1)
         let eventLoop = self.elg.next()
-        try eventLoop.flatSubmit {
+        try eventLoop.flatSubmit { () -> EventLoopFuture<Void> in
             let streamer = HBByteBufferStreamer(eventLoop: eventLoop, maxSize: 32 * 1024)
             streamer.feed(.byteBuffer(buffer))
             streamer.feed(.end)
@@ -292,7 +292,7 @@ class ByteBufferStreamerTests: XCTestCase {
         struct MyError: Error {}
         var buffer = self.randomBuffer(size: 10000)
         let eventLoop = self.elg.next()
-        try eventLoop.flatSubmit { () in
+        try eventLoop.flatSubmit { () -> EventLoopFuture<Void> in
             let streamer = HBByteBufferStreamer(eventLoop: eventLoop, maxSize: 32 * 1024)
 
             while buffer.readableBytes > 0 {

--- a/Tests/HummingbirdCoreTests/StreamerTests.swift
+++ b/Tests/HummingbirdCoreTests/StreamerTests.swift
@@ -90,7 +90,7 @@ class ByteBufferStreamerTests: XCTestCase {
 
     func consumeStreamer(_ streamer: HBByteBufferStreamer, eventLoop: EventLoop) -> EventLoopFuture<ByteBuffer> {
         var consumeBuffer = ByteBuffer()
-        return streamer.consumeAll(on: eventLoop) { buffer in
+        return streamer.consumeAll { buffer in
             var buffer = buffer
             consumeBuffer.writeBuffer(&buffer)
             return eventLoop.makeSucceededVoidFuture()
@@ -99,7 +99,7 @@ class ByteBufferStreamerTests: XCTestCase {
 
     func consumeStreamerWithDelays(_ streamer: HBByteBufferStreamer, eventLoop: EventLoop) -> EventLoopFuture<ByteBuffer> {
         var consumeBuffer = ByteBuffer()
-        return streamer.consumeAll(on: eventLoop) { buffer in
+        return streamer.consumeAll { buffer in
             var buffer = buffer
             consumeBuffer.writeBuffer(&buffer)
             return eventLoop.scheduleTask(in: .microseconds(Int64.random(in: 0..<100))) {}.futureResult
@@ -276,11 +276,11 @@ class ByteBufferStreamerTests: XCTestCase {
             streamer.feed(.byteBuffer(buffer))
             streamer.feed(.end)
 
-            return streamer.consume(on: eventLoop).flatMap { _ in
-                return streamer.consume(on: eventLoop)
+            return streamer.consume().flatMap { _ in
+                return streamer.consume()
             }.flatMap { (end: HBStreamerOutput) in
                 XCTAssertEqual(end, .end)
-                return streamer.consume(on: eventLoop)
+                return streamer.consume()
             }.map { (end: HBStreamerOutput) in
                 XCTAssertEqual(end, .end)
             }


### PR DESCRIPTION
This will always ensure we are on the correct EventLoop when making calls to streamer. Previously there were checks interspersed throughout the code but I may have missed an entry point. It also allows us to make the streamer Sendable without adding `@unchecked`

Because this is now using `NIOLoopBound` I have had to fix up all the tests to ensure the streamer is initialised on the correct EventLoop when