### PR TITLE
Call writeAndFlush for streamed body chunks

### DIFF
--- a/Sources/HummingbirdCore/Server/HTTPServerHandler.swift
+++ b/Sources/HummingbirdCore/Server/HTTPServerHandler.swift
@@ -226,7 +226,7 @@ final class HBHTTPServerHandler: ChannelDuplexHandler, RemovableChannelHandler {
             return context.eventLoop.makeSucceededVoidFuture()
         case .stream(let streamer):
             return streamer.write(on: context.eventLoop) { buffer in
-                context.write(self.wrapOutboundOut(.body(.byteBuffer(buffer))), promise: nil)
+                context.writeAndFlush(self.wrapOutboundOut(.body(.byteBuffer(buffer))), promise: nil)
             }
             .flatAlways { _ in
                 context.writeAndFlush(self.wrapOutboundOut(.end(nil)), promise: nil)


### PR DESCRIPTION
Given we don't know when the next chunk is coming along we should flush the pipeline to ensure the current chunk is sent