### PR TITLE
Add a custom bind address

### DIFF
--- a/Sources/HummingbirdCore/Server/BindAddress.swift
+++ b/Sources/HummingbirdCore/Server/BindAddress.swift
@@ -12,12 +12,16 @@
 //
 //===----------------------------------------------------------------------===//
 
+import NIO
+
 /// Address to bind server to
 public enum HBBindAddress {
     /// bind address define by host and port
     case hostname(_ host: String = "127.0.0.1", port: Int = 8080)
     /// bind address defined by unxi domain socket
     case unixDomainSocket(path: String)
+    /// a custom function used to perform the HTTPServerBootstrap binding
+    case custom((HTTPServerBootstrap) -> EventLoopFuture<Channel>)
 
     /// if address is hostname and port return port
     public var port: Int? {

--- a/Sources/HummingbirdCore/Server/BindAddress.swift
+++ b/Sources/HummingbirdCore/Server/BindAddress.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import NIO
+import NIOCore
 
 /// Address to bind server to
 public enum HBBindAddress {

--- a/Sources/HummingbirdCore/Server/HTTPServer.swift
+++ b/Sources/HummingbirdCore/Server/HTTPServer.swift
@@ -133,6 +133,12 @@ public final class HBHTTPServer {
                     self.channel = channel
                     responder.logger.info("Server started and listening on socket path \(path)")
                 }
+        case .custom(let bindFunction):
+            bindFuture = bindFunction(bootstrap)
+                .map { channel in
+                    self.channel = channel
+                    responder.logger.info("Server started and listening using custom binding function")
+                }
         }
 
         return bindFuture
@@ -229,9 +235,11 @@ public final class HBHTTPServer {
 }
 
 /// Protocol for bootstrap.
-protocol HTTPServerBootstrap {
+public protocol HTTPServerBootstrap {
     func bind(host: String, port: Int) -> EventLoopFuture<Channel>
     func bind(unixDomainSocketPath: String) -> EventLoopFuture<Channel>
+    func serverChannelOption<Option: ChannelOption>(_ option: Option, value: Option.Value) -> Self
+    func childChannelOption<Option: ChannelOption>(_ option: Option, value: Option.Value) -> Self
 }
 
 // Extend both `ServerBootstrap` and `NIOTSListenerBootstrap` to conform to `HTTPServerBootstrap`

--- a/Sources/HummingbirdCore/Server/HTTPServer.swift
+++ b/Sources/HummingbirdCore/Server/HTTPServer.swift
@@ -236,9 +236,33 @@ public final class HBHTTPServer {
 
 /// Protocol for bootstrap.
 public protocol HTTPServerBootstrap {
+    /// Bind the server channel to `host` and `port`.
+    ///
+    /// - parameters:
+    ///     - host: The host to bind on.
+    ///     - port: The port to bind on.
     func bind(host: String, port: Int) -> EventLoopFuture<Channel>
+
+    /// Bind the server channel to a UNIX Domain Socket.
+    ///
+    /// - parameters:
+    ///     - unixDomainSocketPath: The _Unix domain socket_ path to bind to. `unixDomainSocketPath` must not exist, it will be created by the system.
     func bind(unixDomainSocketPath: String) -> EventLoopFuture<Channel>
+    
+    /// Specifies a `ChannelOption` to be applied to the server channel.
+    ///
+    /// - note: To specify options for the accepted child channels, look at `HTTPServerBootstrap.childChannelOption`.
+    ///
+    /// - parameters:
+    ///     - option: The option to be applied.
+    ///     - value: The value for the option.
     func serverChannelOption<Option: ChannelOption>(_ option: Option, value: Option.Value) -> Self
+    
+    /// Specifies a `ChannelOption` to be applied to the accepted child channels.
+    ///
+    /// - parameters:
+    ///     - option: The option to be applied.
+    ///     - value: The value for the option.
     func childChannelOption<Option: ChannelOption>(_ option: Option, value: Option.Value) -> Self
 }
 

--- a/Sources/HummingbirdCore/Server/HTTPServer.swift
+++ b/Sources/HummingbirdCore/Server/HTTPServer.swift
@@ -248,7 +248,7 @@ public protocol HTTPServerBootstrap {
     /// - parameters:
     ///     - unixDomainSocketPath: The _Unix domain socket_ path to bind to. `unixDomainSocketPath` must not exist, it will be created by the system.
     func bind(unixDomainSocketPath: String) -> EventLoopFuture<Channel>
-    
+
     /// Specifies a `ChannelOption` to be applied to the server channel.
     ///
     /// - note: To specify options for the accepted child channels, look at `HTTPServerBootstrap.childChannelOption`.
@@ -257,7 +257,7 @@ public protocol HTTPServerBootstrap {
     ///     - option: The option to be applied.
     ///     - value: The value for the option.
     func serverChannelOption<Option: ChannelOption>(_ option: Option, value: Option.Value) -> Self
-    
+
     /// Specifies a `ChannelOption` to be applied to the accepted child channels.
     ///
     /// - parameters:

--- a/Sources/HummingbirdHTTP2/ChannelInitializer.swift
+++ b/Sources/HummingbirdHTTP2/ChannelInitializer.swift
@@ -41,10 +41,10 @@ struct HTTP2UpgradeChannelInitializer: HBChannelInitializer {
     func initialize(channel: Channel, childHandlers: [RemovableChannelHandler], configuration: HBHTTPServer.Configuration) -> EventLoopFuture<Void> {
         channel.configureHTTP2SecureUpgrade(
             h2ChannelConfigurator: { channel in
-                http2.initialize(channel: channel, childHandlers: childHandlers, configuration: configuration)
+                self.http2.initialize(channel: channel, childHandlers: childHandlers, configuration: configuration)
             },
             http1ChannelConfigurator: { channel in
-                http1.initialize(channel: channel, childHandlers: childHandlers, configuration: configuration)
+                self.http1.initialize(channel: channel, childHandlers: childHandlers, configuration: configuration)
             }
         )
     }

--- a/Tests/HummingbirdCoreTests/CoreTests.swift
+++ b/Tests/HummingbirdCoreTests/CoreTests.swift
@@ -720,10 +720,8 @@ class HummingBirdCoreTests: XCTestCase {
         XCTAssertNoThrow(try timeoutPromise.futureResult.wait())
     }
 
-    func testCustomBindAddress() throws
-    {
-        struct Responder: HBHTTPResponder
-        {
+    func testCustomBindAddress() throws {
+        struct Responder: HBHTTPResponder {
             func respond(to request: HBHTTPRequest, context: ChannelHandlerContext, onComplete: @escaping (Result<HBHTTPResponse, Error>) -> Void) {
                 onComplete(.failure(HBHTTPError(.unauthorized)))
             }
@@ -748,8 +746,7 @@ class HummingBirdCoreTests: XCTestCase {
         defer { XCTAssertNoThrow(try server.stop().wait()) }
 
         XCTAssertTrue(didCallCustomBind)
-        guard let channel = server.channel else
-        {
+        guard let channel = server.channel else {
             throw HBHTTPServer.Error.serverNotRunning
         }
         XCTAssertEqual(channelValue, try channel.getOption(channelOption).wait())

--- a/Tests/HummingbirdCoreTests/CoreTests.swift
+++ b/Tests/HummingbirdCoreTests/CoreTests.swift
@@ -733,7 +733,7 @@ class HummingBirdCoreTests: XCTestCase {
         // value has been set after starting the server.
         // We're testing `SocketOption` option specifically because it is supported by both the `ServerBootstrap` and
         // `NIOTSListenerBootstrap`, allowing this test to be run on all platforms.
-        let channelValue: SocketOptionValue = 12345678
+        let channelValue: SocketOptionValue = 123
         let channelOption = ChannelOptions.Types.SocketOption(level: IPPROTO_TCP, name: TCP_KEEPCNT)
 
         var didCallCustomBind = false

--- a/Tests/HummingbirdCoreTests/CoreTests.swift
+++ b/Tests/HummingbirdCoreTests/CoreTests.swift
@@ -169,6 +169,7 @@ class HummingBirdCoreTests: XCTestCase {
         XCTAssertNoThrow(try future.wait())
     }
 
+    @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     func testConsumeBodyInTask() {
         struct Responder: HBHTTPResponder {
             func respond(to request: HBHTTPRequest, context: ChannelHandlerContext, onComplete: @escaping (Result<HBHTTPResponse, Error>) -> Void) {


### PR DESCRIPTION
As discussed in #62, this PR adds support for specifying a custom function to perform the binding when starting an HTTP server. It also exposes `HTTPServerBootstrap` publicly, and adds functions for easily configuring server and child channel options.

This allows for custom bind functions to be used, such as `NIOTSListenerBootstrap.bind(endpoint: NWEndpoint)`.

I haven't added any additional test cases for the new code because it's so minimal, and there aren't currently any tests testing the other `HBBindingAddress` cases, but I can try come up with some tests if required.