### PR TITLE
Add an HTTP2 event handler to handle quiesce and idle events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
           - 'swift:5.7'
           - 'swift:5.8'
           - 'swift:5.9'
-          - 'swiftlang/swift:nightly-5.10-jammy'
+          #- 'swiftlang/swift:nightly-5.10-jammy'
     
     container:
       image: ${{ matrix.image }}

--- a/Sources/HummingbirdHTTP2/ChannelInitializer.swift
+++ b/Sources/HummingbirdHTTP2/ChannelInitializer.swift
@@ -23,13 +23,13 @@ public struct HTTP2ChannelInitializer: HBChannelInitializer {
     public init() {}
 
     public func initialize(channel: Channel, childHandlers: [RemovableChannelHandler], configuration: HBHTTPServer.Configuration) -> EventLoopFuture<Void> {
-        return channel.configureHTTP2Pipeline(mode: .server) { streamChannel -> EventLoopFuture<Void> in
+        channel.configureHTTP2Pipeline(mode: .server) { streamChannel -> EventLoopFuture<Void> in
             return streamChannel.pipeline.addHandler(HTTP2FramePayloadToHTTP1ServerCodec()).flatMap { _ in
                 streamChannel.pipeline.addHandlers(childHandlers)
             }
-            .map { _ in }
+        }.flatMap { _ in
+            channel.pipeline.addHandler(HTTP2UserEventHandler())
         }
-        .map { _ in }
     }
 }
 

--- a/Sources/HummingbirdHTTP2/ChannelInitializer.swift
+++ b/Sources/HummingbirdHTTP2/ChannelInitializer.swift
@@ -42,7 +42,7 @@ public struct HTTP2ChannelInitializer: HBChannelInitializer {
                 channel.pipeline.addHandler(HTTP2UserEventHandler())
             }
         }
-        if let idleReadTimeout = self.idleReadTimeout {
+        if let idleReadTimeout {
             return channel.pipeline.addHandler(IdleStateHandler(readTimeout: idleReadTimeout)).flatMap {
                 configureHTTP2Pipeline()
             }

--- a/Sources/HummingbirdHTTP2/ChannelInitializer.swift
+++ b/Sources/HummingbirdHTTP2/ChannelInitializer.swift
@@ -20,23 +20,66 @@ import NIOSSL
 
 /// Setup child channel for HTTP2
 public struct HTTP2ChannelInitializer: HBChannelInitializer {
-    public init() {}
+    /// Idle state handler configuration for HTTP2 channel
+    public struct IdleStateHandlerConfiguration: Sendable {
+        /// timeout when reading a request
+        let readTimeout: TimeAmount
+        /// timeout since last writing a response
+        let writeTimeout: TimeAmount
 
-    public func initialize(channel: Channel, childHandlers: [RemovableChannelHandler], configuration: HBHTTPServer.Configuration) -> EventLoopFuture<Void> {
-        channel.configureHTTP2Pipeline(mode: .server) { streamChannel -> EventLoopFuture<Void> in
-            return streamChannel.pipeline.addHandler(HTTP2FramePayloadToHTTP1ServerCodec()).flatMap { _ in
-                streamChannel.pipeline.addHandlers(childHandlers)
-            }
-        }.flatMap { _ in
-            channel.pipeline.addHandler(HTTP2UserEventHandler())
+        public init(readTimeout: TimeAmount = .seconds(30), writeTimeout: TimeAmount = .minutes(3)) {
+            self.readTimeout = readTimeout
+            self.writeTimeout = writeTimeout
+        }
+
+        public var idleStateHandler: IdleStateHandler {
+            IdleStateHandler(readTimeout: self.readTimeout, writeTimeout: self.writeTimeout)
         }
     }
+
+    /// Initialise HTTP2ChannelInitializer
+    @available(*, deprecated, renamed: "init(idleTimeoutConfiguration:)")
+    public init() {
+        self.idleTimeoutConfiguration = nil
+    }
+
+    /// Initialise HTTP2ChannelInitializer
+    /// - Parameter idleTimeoutConfiguration: Configure when server should close the channel based of idle events
+    public init(idleTimeoutConfiguration: IdleStateHandlerConfiguration?) {
+        self.idleTimeoutConfiguration = idleTimeoutConfiguration
+    }
+
+    public func initialize(channel: Channel, childHandlers: [RemovableChannelHandler], configuration: HBHTTPServer.Configuration) -> EventLoopFuture<Void> {
+        func configureHTTP2Pipeline() -> EventLoopFuture<Void> {
+            channel.configureHTTP2Pipeline(mode: .server) { streamChannel -> EventLoopFuture<Void> in
+                return streamChannel.pipeline.addHandler(HTTP2FramePayloadToHTTP1ServerCodec()).flatMap { _ in
+                    streamChannel.pipeline.addHandlers(childHandlers)
+                }
+            }.flatMap { _ in
+                channel.pipeline.addHandler(HTTP2UserEventHandler())
+            }
+        }
+        if let idleTimeoutConfiguration = self.idleTimeoutConfiguration {
+            return channel.pipeline.addHandler(idleTimeoutConfiguration.idleStateHandler).flatMap {
+                configureHTTP2Pipeline()
+            }
+        } else {
+            return configureHTTP2Pipeline()
+        }
+    }
+
+    let idleTimeoutConfiguration: IdleStateHandlerConfiguration?
 }
 
 /// Setup child channel for HTTP2 upgrade
 struct HTTP2UpgradeChannelInitializer: HBChannelInitializer {
-    var http1 = HTTP1ChannelInitializer()
-    let http2 = HTTP2ChannelInitializer()
+    var http1: HTTP1ChannelInitializer
+    let http2: HTTP2ChannelInitializer
+
+    init(idleTimeoutConfiguration: HTTP2ChannelInitializer.IdleStateHandlerConfiguration?) {
+        self.http1 = HTTP1ChannelInitializer()
+        self.http2 = HTTP2ChannelInitializer(idleTimeoutConfiguration: idleTimeoutConfiguration)
+    }
 
     func initialize(channel: Channel, childHandlers: [RemovableChannelHandler], configuration: HBHTTPServer.Configuration) -> EventLoopFuture<Void> {
         channel.configureHTTP2SecureUpgrade(

--- a/Sources/HummingbirdHTTP2/HTTP2UserEventHandler.swift
+++ b/Sources/HummingbirdHTTP2/HTTP2UserEventHandler.swift
@@ -1,0 +1,77 @@
+import NIOCore
+import NIOHTTP2
+
+final class HTTP2UserEventHandler: ChannelInboundHandler, RemovableChannelHandler {
+    typealias InboundIn = HTTP2Frame
+    typealias InboundOut = HTTP2Frame
+
+    enum State {
+        case active(numberOpenStreams: Int)
+        case quiescing(numberOpenStreams: Int)
+        case closing
+    }
+
+    var state: State = .active(numberOpenStreams: 0)
+
+    public func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+        context.fireChannelRead(data)
+    }
+
+    public func userInboundEventTriggered(context: ChannelHandlerContext, event: Any) {
+        switch event {
+        case is NIOHTTP2StreamCreatedEvent:
+            self.streamOpened()
+
+        case is StreamClosedEvent:
+            self.streamClosed(context: context)
+
+        case is ChannelShouldQuiesceEvent:
+            self.quiesce(context: context)
+
+        default:
+            break
+        }
+        context.fireUserInboundEventTriggered(event)
+    }
+
+    func streamOpened() {
+        switch self.state {
+        case .active(let numberOpenStreams):
+            self.state = .active(numberOpenStreams: numberOpenStreams + 1)
+        case .quiescing(let numberOpenStreams):
+            self.state = .quiescing(numberOpenStreams: numberOpenStreams + 1)
+        case .closing:
+            assertionFailure("If we have initiated a close, then we should not be opening new streams.")
+        }
+    }
+
+    func streamClosed(context: ChannelHandlerContext) {
+        switch self.state {
+        case .active(let numberOpenStreams):
+            self.state = .active(numberOpenStreams: numberOpenStreams - 1)
+        case .quiescing(let numberOpenStreams):
+            if numberOpenStreams > 1 {
+                self.state = .quiescing(numberOpenStreams: numberOpenStreams - 1)
+            } else {
+                self.state = .closing
+                context.close(promise: nil)
+            }
+        case .closing:
+            assertionFailure("If we have initiated a close, there should be no streams to close.")
+        }
+    }
+
+    func quiesce(context: ChannelHandlerContext) {
+        switch self.state {
+        case .active(let numberOpenStreams):
+            if numberOpenStreams > 0 {
+                self.state = .quiescing(numberOpenStreams: numberOpenStreams)
+            } else {
+                self.state = .closing
+                context.close(promise: nil)
+            }
+        case .quiescing, .closing:
+            break
+        }
+    }
+}

--- a/Sources/HummingbirdHTTP2/HTTP2UserEventHandler.swift
+++ b/Sources/HummingbirdHTTP2/HTTP2UserEventHandler.swift
@@ -98,16 +98,9 @@ final class HTTP2UserEventHandler: ChannelInboundHandler, RemovableChannelHandle
 
     func processIdleWriteState(context: ChannelHandlerContext) {
         switch self.state {
-        case .active(let numberOpenStreams):
+        case .active(0), .quiescing(0):
             // if we get a write idle state and there are no longer any streams open
-            if numberOpenStreams == 0 {
-                self.close(context: context)
-            }
-        case .quiescing(let numberOpenStreams):
-            // if we get a write idle state and there are no longer any streams open
-            if numberOpenStreams == 0 {
-                self.close(context: context)
-            }
+            self.close(context: context)
         default:
             break
         }

--- a/Sources/HummingbirdHTTP2/HTTPServer+HTTP2.swift
+++ b/Sources/HummingbirdHTTP2/HTTPServer+HTTP2.swift
@@ -22,13 +22,35 @@ extension HBHTTPServer {
     /// you will then be adding two TLS handlers.
     ///
     /// - Parameter tlsConfiguration: TLS configuration
+    @available(*, deprecated, renamed: "addHTTP2Upgrade(tlsConfiguration:idleTimeoutConfiguration:)")
     @discardableResult public func addHTTP2Upgrade(tlsConfiguration: TLSConfiguration) throws -> HBHTTPServer {
         var tlsConfiguration = tlsConfiguration
         tlsConfiguration.applicationProtocols.append("h2")
         tlsConfiguration.applicationProtocols.append("http/1.1")
         let sslContext = try NIOSSLContext(configuration: tlsConfiguration)
 
-        self.httpChannelInitializer = HTTP2UpgradeChannelInitializer()
+        self.httpChannelInitializer = HTTP2UpgradeChannelInitializer(idleTimeoutConfiguration: nil)
+        return self.addTLSChannelHandler(NIOSSLServerHandler(context: sslContext))
+    }
+
+    /// Add HTTP2 secure upgrade handler
+    ///
+    /// HTTP2 secure upgrade requires a TLS connection so this will add a TLS handler as well. Do not call `addTLS()` inconjunction with this as
+    /// you will then be adding two TLS handlers.
+    ///
+    /// - Parameters:
+    ///   - tlsConfiguration: TLS configuration
+    ///   - idleTimeoutConfiguration: Configure when server should close the channel based of idle events
+    @discardableResult public func addHTTP2Upgrade(
+        tlsConfiguration: TLSConfiguration,
+        idleTimeoutConfiguration: HTTP2ChannelInitializer.IdleStateHandlerConfiguration
+    ) throws -> HBHTTPServer {
+        var tlsConfiguration = tlsConfiguration
+        tlsConfiguration.applicationProtocols.append("h2")
+        tlsConfiguration.applicationProtocols.append("http/1.1")
+        let sslContext = try NIOSSLContext(configuration: tlsConfiguration)
+
+        self.httpChannelInitializer = HTTP2UpgradeChannelInitializer(idleTimeoutConfiguration: idleTimeoutConfiguration)
         return self.addTLSChannelHandler(NIOSSLServerHandler(context: sslContext))
     }
 }

--- a/Sources/HummingbirdHTTP2/HTTPServer+HTTP2.swift
+++ b/Sources/HummingbirdHTTP2/HTTPServer+HTTP2.swift
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import HummingbirdCore
+import NIOCore
 import NIOSSL
 
 extension HBHTTPServer {
@@ -22,14 +23,14 @@ extension HBHTTPServer {
     /// you will then be adding two TLS handlers.
     ///
     /// - Parameter tlsConfiguration: TLS configuration
-    @available(*, deprecated, renamed: "addHTTP2Upgrade(tlsConfiguration:idleTimeoutConfiguration:)")
+    @available(*, deprecated, renamed: "addHTTP2Upgrade(tlsConfiguration:idleReadTimeout:)")
     @discardableResult public func addHTTP2Upgrade(tlsConfiguration: TLSConfiguration) throws -> HBHTTPServer {
         var tlsConfiguration = tlsConfiguration
         tlsConfiguration.applicationProtocols.append("h2")
         tlsConfiguration.applicationProtocols.append("http/1.1")
         let sslContext = try NIOSSLContext(configuration: tlsConfiguration)
 
-        self.httpChannelInitializer = HTTP2UpgradeChannelInitializer(idleTimeoutConfiguration: nil)
+        self.httpChannelInitializer = HTTP2UpgradeChannelInitializer(idleReadTimeout: nil)
         return self.addTLSChannelHandler(NIOSSLServerHandler(context: sslContext))
     }
 
@@ -43,14 +44,14 @@ extension HBHTTPServer {
     ///   - idleTimeoutConfiguration: Configure when server should close the channel based of idle events
     @discardableResult public func addHTTP2Upgrade(
         tlsConfiguration: TLSConfiguration,
-        idleTimeoutConfiguration: HTTP2ChannelInitializer.IdleStateHandlerConfiguration
+        idleReadTimeout: TimeAmount
     ) throws -> HBHTTPServer {
         var tlsConfiguration = tlsConfiguration
         tlsConfiguration.applicationProtocols.append("h2")
         tlsConfiguration.applicationProtocols.append("http/1.1")
         let sslContext = try NIOSSLContext(configuration: tlsConfiguration)
 
-        self.httpChannelInitializer = HTTP2UpgradeChannelInitializer(idleTimeoutConfiguration: idleTimeoutConfiguration)
+        self.httpChannelInitializer = HTTP2UpgradeChannelInitializer(idleReadTimeout: idleReadTimeout)
         return self.addTLSChannelHandler(NIOSSLServerHandler(context: sslContext))
     }
 }


### PR DESCRIPTION
These changes are for 1.0. We will need to bring the idle state handling across to 2.0 at some point. We already support quiesce via graceful shutdown. 